### PR TITLE
Adding GCP CIS compute benchmark policies

### DIFF
--- a/gcp/compute/README.md
+++ b/gcp/compute/README.md
@@ -1,0 +1,74 @@
+#  CIS Google Cloud Computing Foundational Sentinel policies
+
+The following code snippets show the configuration settings that are required to successfully deploy Sentinel policies that follow the security recommendations that are provided in the [CIS Google Cloud Computing Platform Foundations Benchmark v.1.0.0](https://www.cisecurity.org/benchmark/google_cloud_computing_platform/). We cover policy configuration in more details in the [Managing Sentinel Policies](https://www.terraform.io/docs/cloud/sentinel/manage-policies.html) section in the Terraform Cloud [documentation](https://www.terraform.io/docs/cloud/index.html).
+
+## CIS 4.2: Ensure "Block Project-wide SSH keys" enabled for VM instances
+
+### Description
+Project-wide SSH keys are stored in Compute/Project-meta-data. Project wide SSH keys can be used to login into all the instances within project. Using project-wide SSH keys eases the SSH key management but if compromised, poses the security risk which can impact all the instances within project. It is recommended to use Instance specific SSH keys which can limit the attack surface if the SSH keys are compromised.
+
+### Configuration
+
+```hcl
+policy "gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/compute/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances.sentinel"
+    enforcement_level = "advisory"
+}
+```
+## CIS 4.3: Ensure oslogin is enabled for a Project
+
+### Description
+Enabling osLogin ensures that SSH keys used to connect to instances are mapped with IAM users. Revoking access to IAM user will revoke all the SSH keys associated with that particular user. It facilitates centralized and automated SSH key pair management which is useful in handling cases like response to compromised SSH key pairs and/or revocation of external/third-party/Vendor users.
+
+### Configuration
+
+```hcl
+policy "gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/compute/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 4.4: Ensure 'Enable connecting to serial ports' is not enabled for VM Instance
+
+### Description
+If you enable the interactive serial console on an instance, clients can attempt to connect to that instance from any IP address. Therefore interactive serial console support should be disabled.
+
+### Configuration
+```hcl
+policy "gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/compute/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 4.5: Ensure that IP forwarding is not enabled on Instances
+
+### Description
+Compute Engine instance cannot forward a packet unless the source IP address of the packet matches the IP address of the instance. Similarly, GCP won't deliver a packet whose destination IP address is different than the IP address of the instance receiving the packet. However, both capabilities are required if you want to use instances to help route packets. Forwarding of data packets should be disabled to prevent data loss or information disclosure.
+
+### Configuration
+
+```hcl
+policy "gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/compute/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 4.6: Ensure VM disks for critical VMs are encrypted with Customer- Supplied Encryption Keys (CSEK)
+
+### Description
+If you provide your own encryption keys, Compute Engine uses your key to protect the Google-generated keys used to encrypt and decrypt your data. Only users who can provide the correct key can use resources protected by a customer-supplied encryption key. Google does not store your keys on its servers and cannot access your protected data unless you provide the key.
+
+> **Note:**
+If you forget or lose your key, there is no way for Google to recover the key or to recover any data encrypted with the lost key.
+
+### Configuration
+
+```hcl
+policy "gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/compute/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys.sentinel"
+    enforcement_level = "advisory"
+}
+```

--- a/gcp/compute/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances.sentinel
+++ b/gcp/compute/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances.sentinel
@@ -1,0 +1,33 @@
+import "tfplan/v2" as tfplan
+import "strings"
+
+allComputeInstances = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_compute_instance" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+allComputeInstanceTemplates = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_compute_instance_template" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 4.2: Ensure 'Block Project-wide SSH keys' are enabled for VM instances")
+
+block_project_ssh_keys_is_enabled_in_compute_instance_metadata = rule {
+	all allComputeInstances as _, instance {
+		strings.to_lower(instance.change.after.metadata["block-project-ssh-keys"]) is "true"
+	}
+}
+
+block_project_ssh_keys_is_enabled_in_compute_instance_template_metadata = rule {
+	all allComputeInstanceTemplates as _, template {
+		strings.to_lower(template.change.after.metadata["block-project-ssh-keys"]) is "true"
+	}
+}
+
+main = rule {
+	block_project_ssh_keys_is_enabled_in_compute_instance_metadata and
+	block_project_ssh_keys_is_enabled_in_compute_instance_template_metadata
+}

--- a/gcp/compute/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/test/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/failure.json
+++ b/gcp/compute/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/test/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/compute/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/test/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/success.json
+++ b/gcp/compute/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/test/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/compute/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/compute/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,221 @@
+resource_changes = {
+	"google_compute_instance.this": {
+		"address": "google_compute_instance.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"allow_stopping_for_update": null,
+				"attached_disk": [
+					{
+						"disk_encryption_key_raw": null,
+						"kms_key_self_link":       "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+						"mode":                    "READ_WRITE",
+						"source":                  "this",
+					},
+					{
+						"disk_encryption_key_raw": null,
+						"mode":   "READ_WRITE",
+						"source": "that",
+					},
+				],
+				"boot_disk": [
+					{
+						"auto_delete":             true,
+						"disk_encryption_key_raw": null,
+						"initialize_params": [
+							{
+								"image": "debian-cloud/debian-9",
+							},
+						],
+						"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+						"mode":              "READ_WRITE",
+					},
+				],
+				"can_ip_forward":      false,
+				"deletion_protection": false,
+				"description":         null,
+				"desired_status":      null,
+				"enable_display":      null,
+				"hostname":            null,
+				"labels":              null,
+				"machine_type":        "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": "echo hi > /test.txt",
+				"name": "test",
+				"network_interface": [
+					{
+						"access_config": [
+							{
+								"public_ptr_domain_name": null,
+							},
+						],
+						"alias_ip_range": [],
+						"network":        "default",
+					},
+				],
+				"scratch_disk": [
+					{
+						"interface": "SCSI",
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+				"timeouts": null,
+				"zone":     "australia-southeast1-a",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance",
+	},
+	"google_compute_instance_template.this": {
+		"address": "google_compute_instance_template.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"can_ip_forward": false,
+				"description":    "This template is used to create app server instances.",
+				"disk": [
+					{
+						"auto_delete": true,
+						"boot":        true,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       null,
+						"source_image": "debian-cloud/debian-9",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "this",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "that",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "where",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "at",
+					},
+				],
+				"enable_display":       null,
+				"guest_accelerator":    [],
+				"instance_description": "description assigned to instances",
+				"labels": {
+					"environment": "dev",
+				},
+				"machine_type": "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": null,
+				"min_cpu_platform":        null,
+				"name":                    "appserver-template",
+				"network_interface": [
+					{
+						"access_config":  [],
+						"alias_ip_range": [],
+						"network":        "default",
+						"network_ip":     null,
+					},
+				],
+				"scheduling": [
+					{
+						"automatic_restart":   true,
+						"node_affinities":     [],
+						"on_host_maintenance": "MIGRATE",
+						"preemptible":         false,
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance_template",
+	},
+}

--- a/gcp/compute/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/testdata/mock-tfplan-success.sentinel
+++ b/gcp/compute/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,221 @@
+resource_changes = {
+	"google_compute_instance.this": {
+		"address": "google_compute_instance.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"allow_stopping_for_update": null,
+				"attached_disk": [
+					{
+						"disk_encryption_key_raw": null,
+						"kms_key_self_link":       "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+						"mode":                    "READ_WRITE",
+						"source":                  "this",
+					},
+					{
+						"disk_encryption_key_raw": null,
+						"mode":   "READ_WRITE",
+						"source": "that",
+					},
+				],
+				"boot_disk": [
+					{
+						"auto_delete":             true,
+						"disk_encryption_key_raw": null,
+						"initialize_params": [
+							{
+								"image": "debian-cloud/debian-9",
+							},
+						],
+						"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+						"mode":              "READ_WRITE",
+					},
+				],
+				"can_ip_forward":      false,
+				"deletion_protection": false,
+				"description":         null,
+				"desired_status":      null,
+				"enable_display":      null,
+				"hostname":            null,
+				"labels":              null,
+				"machine_type":        "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "true",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": "echo hi > /test.txt",
+				"name": "test",
+				"network_interface": [
+					{
+						"access_config": [
+							{
+								"public_ptr_domain_name": null,
+							},
+						],
+						"alias_ip_range": [],
+						"network":        "default",
+					},
+				],
+				"scratch_disk": [
+					{
+						"interface": "SCSI",
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+				"timeouts": null,
+				"zone":     "australia-southeast1-a",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance",
+	},
+	"google_compute_instance_template.this": {
+		"address": "google_compute_instance_template.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"can_ip_forward": false,
+				"description":    "This template is used to create app server instances.",
+				"disk": [
+					{
+						"auto_delete": true,
+						"boot":        true,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       null,
+						"source_image": "debian-cloud/debian-9",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "this",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "that",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "where",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "at",
+					},
+				],
+				"enable_display":       null,
+				"guest_accelerator":    [],
+				"instance_description": "description assigned to instances",
+				"labels": {
+					"environment": "dev",
+				},
+				"machine_type": "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "true",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": null,
+				"min_cpu_platform":        null,
+				"name":                    "appserver-template",
+				"network_interface": [
+					{
+						"access_config":  [],
+						"alias_ip_range": [],
+						"network":        "default",
+						"network_ip":     null,
+					},
+				],
+				"scheduling": [
+					{
+						"automatic_restart":   true,
+						"node_affinities":     [],
+						"on_host_maintenance": "MIGRATE",
+						"preemptible":         false,
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance_template",
+	},
+}

--- a/gcp/compute/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project.sentinel
+++ b/gcp/compute/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project.sentinel
@@ -1,0 +1,33 @@
+import "tfplan/v2" as tfplan
+import "strings"
+
+allComputeInstances = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_compute_instance" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+allComputeInstanceTemplates = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_compute_instance_template" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 4.3: Ensure oslogin is enabled for a project")
+
+enable_oslogin_is_enabled_in_compute_instance_metadata = rule {
+	all allComputeInstances as _, instance {
+		strings.to_lower(instance.change.after.metadata["enable-oslogin"]) is "true"
+	}
+}
+
+enable_oslogin_is_enabled_in_compute_instance_template_metadata = rule {
+	all allComputeInstanceTemplates as _, template {
+		strings.to_lower(template.change.after.metadata["enable-oslogin"]) is "true"
+	}
+}
+
+main = rule {
+	enable_oslogin_is_enabled_in_compute_instance_metadata and
+	enable_oslogin_is_enabled_in_compute_instance_template_metadata
+}

--- a/gcp/compute/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/test/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/failure.json
+++ b/gcp/compute/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/test/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/compute/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/test/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/success.json
+++ b/gcp/compute/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/test/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/compute/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/compute/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,221 @@
+resource_changes = {
+	"google_compute_instance.this": {
+		"address": "google_compute_instance.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"allow_stopping_for_update": null,
+				"attached_disk": [
+					{
+						"disk_encryption_key_raw": null,
+						"kms_key_self_link":       "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+						"mode":                    "READ_WRITE",
+						"source":                  "this",
+					},
+					{
+						"disk_encryption_key_raw": null,
+						"mode":   "READ_WRITE",
+						"source": "that",
+					},
+				],
+				"boot_disk": [
+					{
+						"auto_delete":             true,
+						"disk_encryption_key_raw": null,
+						"initialize_params": [
+							{
+								"image": "debian-cloud/debian-9",
+							},
+						],
+						"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+						"mode":              "READ_WRITE",
+					},
+				],
+				"can_ip_forward":      false,
+				"deletion_protection": false,
+				"description":         null,
+				"desired_status":      null,
+				"enable_display":      null,
+				"hostname":            null,
+				"labels":              null,
+				"machine_type":        "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "false",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": "echo hi > /test.txt",
+				"name": "test",
+				"network_interface": [
+					{
+						"access_config": [
+							{
+								"public_ptr_domain_name": null,
+							},
+						],
+						"alias_ip_range": [],
+						"network":        "default",
+					},
+				],
+				"scratch_disk": [
+					{
+						"interface": "SCSI",
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+				"timeouts": null,
+				"zone":     "australia-southeast1-a",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance",
+	},
+	"google_compute_instance_template.this": {
+		"address": "google_compute_instance_template.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"can_ip_forward": false,
+				"description":    "This template is used to create app server instances.",
+				"disk": [
+					{
+						"auto_delete": true,
+						"boot":        true,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       null,
+						"source_image": "debian-cloud/debian-9",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "this",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "that",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "where",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "at",
+					},
+				],
+				"enable_display":       null,
+				"guest_accelerator":    [],
+				"instance_description": "description assigned to instances",
+				"labels": {
+					"environment": "dev",
+				},
+				"machine_type": "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "false",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": null,
+				"min_cpu_platform":        null,
+				"name":                    "appserver-template",
+				"network_interface": [
+					{
+						"access_config":  [],
+						"alias_ip_range": [],
+						"network":        "default",
+						"network_ip":     null,
+					},
+				],
+				"scheduling": [
+					{
+						"automatic_restart":   true,
+						"node_affinities":     [],
+						"on_host_maintenance": "MIGRATE",
+						"preemptible":         false,
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance_template",
+	},
+}

--- a/gcp/compute/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/testdata/mock-tfplan-success.sentinel
+++ b/gcp/compute/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,221 @@
+resource_changes = {
+	"google_compute_instance.this": {
+		"address": "google_compute_instance.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"allow_stopping_for_update": null,
+				"attached_disk": [
+					{
+						"disk_encryption_key_raw": null,
+						"kms_key_self_link":       "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+						"mode":                    "READ_WRITE",
+						"source":                  "this",
+					},
+					{
+						"disk_encryption_key_raw": null,
+						"mode":   "READ_WRITE",
+						"source": "that",
+					},
+				],
+				"boot_disk": [
+					{
+						"auto_delete":             true,
+						"disk_encryption_key_raw": null,
+						"initialize_params": [
+							{
+								"image": "debian-cloud/debian-9",
+							},
+						],
+						"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+						"mode":              "READ_WRITE",
+					},
+				],
+				"can_ip_forward":      false,
+				"deletion_protection": false,
+				"description":         null,
+				"desired_status":      null,
+				"enable_display":      null,
+				"hostname":            null,
+				"labels":              null,
+				"machine_type":        "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "true",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": "echo hi > /test.txt",
+				"name": "test",
+				"network_interface": [
+					{
+						"access_config": [
+							{
+								"public_ptr_domain_name": null,
+							},
+						],
+						"alias_ip_range": [],
+						"network":        "default",
+					},
+				],
+				"scratch_disk": [
+					{
+						"interface": "SCSI",
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+				"timeouts": null,
+				"zone":     "australia-southeast1-a",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance",
+	},
+	"google_compute_instance_template.this": {
+		"address": "google_compute_instance_template.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"can_ip_forward": false,
+				"description":    "This template is used to create app server instances.",
+				"disk": [
+					{
+						"auto_delete": true,
+						"boot":        true,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       null,
+						"source_image": "debian-cloud/debian-9",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "this",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "that",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "where",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "at",
+					},
+				],
+				"enable_display":       null,
+				"guest_accelerator":    [],
+				"instance_description": "description assigned to instances",
+				"labels": {
+					"environment": "dev",
+				},
+				"machine_type": "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "true",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": null,
+				"min_cpu_platform":        null,
+				"name":                    "appserver-template",
+				"network_interface": [
+					{
+						"access_config":  [],
+						"alias_ip_range": [],
+						"network":        "default",
+						"network_ip":     null,
+					},
+				],
+				"scheduling": [
+					{
+						"automatic_restart":   true,
+						"node_affinities":     [],
+						"on_host_maintenance": "MIGRATE",
+						"preemptible":         false,
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance_template",
+	},
+}

--- a/gcp/compute/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance.sentinel
+++ b/gcp/compute/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance.sentinel
@@ -1,0 +1,33 @@
+import "tfplan/v2" as tfplan
+import "strings"
+
+allComputeInstances = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_compute_instance" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+allComputeInstanceTemplates = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_compute_instance_template" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 4.4: Ensure 'Enable connecting to serial ports' is not enabled for VM Instance")
+
+serial_port_enable_is_disabled_in_compute_instance_metadata = rule {
+	all allComputeInstances as _, instance {
+		strings.to_lower(instance.change.after.metadata["serial-port-enable"]) is "false"
+	}
+}
+
+serial_port_enable_is_disabled_in_compute_instance_template_metadata = rule {
+	all allComputeInstanceTemplates as _, template {
+		strings.to_lower(template.change.after.metadata["serial-port-enable"]) is "false"
+	}
+}
+
+main = rule {
+	serial_port_enable_is_disabled_in_compute_instance_metadata and
+	serial_port_enable_is_disabled_in_compute_instance_template_metadata
+}

--- a/gcp/compute/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/test/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/failure.json
+++ b/gcp/compute/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/test/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/compute/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/test/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/success.json
+++ b/gcp/compute/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/test/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/compute/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/compute/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,221 @@
+resource_changes = {
+	"google_compute_instance.this": {
+		"address": "google_compute_instance.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"allow_stopping_for_update": null,
+				"attached_disk": [
+					{
+						"disk_encryption_key_raw": null,
+						"kms_key_self_link":       "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+						"mode":                    "READ_WRITE",
+						"source":                  "this",
+					},
+					{
+						"disk_encryption_key_raw": null,
+						"mode":   "READ_WRITE",
+						"source": "that",
+					},
+				],
+				"boot_disk": [
+					{
+						"auto_delete":             true,
+						"disk_encryption_key_raw": null,
+						"initialize_params": [
+							{
+								"image": "debian-cloud/debian-9",
+							},
+						],
+						"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+						"mode":              "READ_WRITE",
+					},
+				],
+				"can_ip_forward":      false,
+				"deletion_protection": false,
+				"description":         null,
+				"desired_status":      null,
+				"enable_display":      null,
+				"hostname":            null,
+				"labels":              null,
+				"machine_type":        "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "false",
+					"serial-port-enable":     "true",
+				},
+				"metadata_startup_script": "echo hi > /test.txt",
+				"name": "test",
+				"network_interface": [
+					{
+						"access_config": [
+							{
+								"public_ptr_domain_name": null,
+							},
+						],
+						"alias_ip_range": [],
+						"network":        "default",
+					},
+				],
+				"scratch_disk": [
+					{
+						"interface": "SCSI",
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+				"timeouts": null,
+				"zone":     "australia-southeast1-a",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance",
+	},
+	"google_compute_instance_template.this": {
+		"address": "google_compute_instance_template.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"can_ip_forward": false,
+				"description":    "This template is used to create app server instances.",
+				"disk": [
+					{
+						"auto_delete": true,
+						"boot":        true,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       null,
+						"source_image": "debian-cloud/debian-9",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "this",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "that",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "where",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "at",
+					},
+				],
+				"enable_display":       null,
+				"guest_accelerator":    [],
+				"instance_description": "description assigned to instances",
+				"labels": {
+					"environment": "dev",
+				},
+				"machine_type": "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "false",
+					"serial-port-enable":     "true",
+				},
+				"metadata_startup_script": null,
+				"min_cpu_platform":        null,
+				"name":                    "appserver-template",
+				"network_interface": [
+					{
+						"access_config":  [],
+						"alias_ip_range": [],
+						"network":        "default",
+						"network_ip":     null,
+					},
+				],
+				"scheduling": [
+					{
+						"automatic_restart":   true,
+						"node_affinities":     [],
+						"on_host_maintenance": "MIGRATE",
+						"preemptible":         false,
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance_template",
+	},
+}

--- a/gcp/compute/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/testdata/mock-tfplan-success.sentinel
+++ b/gcp/compute/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,221 @@
+resource_changes = {
+	"google_compute_instance.this": {
+		"address": "google_compute_instance.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"allow_stopping_for_update": null,
+				"attached_disk": [
+					{
+						"disk_encryption_key_raw": null,
+						"kms_key_self_link":       "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+						"mode":                    "READ_WRITE",
+						"source":                  "this",
+					},
+					{
+						"disk_encryption_key_raw": null,
+						"mode":   "READ_WRITE",
+						"source": "that",
+					},
+				],
+				"boot_disk": [
+					{
+						"auto_delete":             true,
+						"disk_encryption_key_raw": null,
+						"initialize_params": [
+							{
+								"image": "debian-cloud/debian-9",
+							},
+						],
+						"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+						"mode":              "READ_WRITE",
+					},
+				],
+				"can_ip_forward":      false,
+				"deletion_protection": false,
+				"description":         null,
+				"desired_status":      null,
+				"enable_display":      null,
+				"hostname":            null,
+				"labels":              null,
+				"machine_type":        "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "true",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": "echo hi > /test.txt",
+				"name": "test",
+				"network_interface": [
+					{
+						"access_config": [
+							{
+								"public_ptr_domain_name": null,
+							},
+						],
+						"alias_ip_range": [],
+						"network":        "default",
+					},
+				],
+				"scratch_disk": [
+					{
+						"interface": "SCSI",
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+				"timeouts": null,
+				"zone":     "australia-southeast1-a",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance",
+	},
+	"google_compute_instance_template.this": {
+		"address": "google_compute_instance_template.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"can_ip_forward": false,
+				"description":    "This template is used to create app server instances.",
+				"disk": [
+					{
+						"auto_delete": true,
+						"boot":        true,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       null,
+						"source_image": "debian-cloud/debian-9",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "this",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "that",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "where",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "at",
+					},
+				],
+				"enable_display":       null,
+				"guest_accelerator":    [],
+				"instance_description": "description assigned to instances",
+				"labels": {
+					"environment": "dev",
+				},
+				"machine_type": "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "true",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": null,
+				"min_cpu_platform":        null,
+				"name":                    "appserver-template",
+				"network_interface": [
+					{
+						"access_config":  [],
+						"alias_ip_range": [],
+						"network":        "default",
+						"network_ip":     null,
+					},
+				],
+				"scheduling": [
+					{
+						"automatic_restart":   true,
+						"node_affinities":     [],
+						"on_host_maintenance": "MIGRATE",
+						"preemptible":         false,
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance_template",
+	},
+}

--- a/gcp/compute/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances.sentinel
+++ b/gcp/compute/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances.sentinel
@@ -1,0 +1,32 @@
+import "tfplan/v2" as tfplan
+
+allComputeInstances = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_compute_instance" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+allComputeInstanceTemplates = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_compute_instance_template" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 4.5: Ensure that IP forwarding is not enabled on Instances")
+
+can_ip_forward_is_disabled_in_compute_instance = rule {
+	all allComputeInstances as _, instance {
+		instance.change.after.can_ip_forward is false
+	}
+}
+
+can_ip_forward_is_disabled_in_compute_instance_template = rule {
+	all allComputeInstanceTemplates as _, template {
+		template.change.after.can_ip_forward is false
+	}
+}
+
+main = rule {
+	can_ip_forward_is_disabled_in_compute_instance and
+	can_ip_forward_is_disabled_in_compute_instance_template
+}

--- a/gcp/compute/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances/test/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances/failure.json
+++ b/gcp/compute/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances/test/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/compute/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances/test/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances/success.json
+++ b/gcp/compute/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances/test/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/compute/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/compute/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,221 @@
+resource_changes = {
+	"google_compute_instance.this": {
+		"address": "google_compute_instance.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"allow_stopping_for_update": null,
+				"attached_disk": [
+					{
+						"disk_encryption_key_raw": null,
+						"kms_key_self_link":       "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+						"mode":                    "READ_WRITE",
+						"source":                  "this",
+					},
+					{
+						"disk_encryption_key_raw": null,
+						"mode":   "READ_WRITE",
+						"source": "that",
+					},
+				],
+				"boot_disk": [
+					{
+						"auto_delete":             true,
+						"disk_encryption_key_raw": null,
+						"initialize_params": [
+							{
+								"image": "debian-cloud/debian-9",
+							},
+						],
+						"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+						"mode":              "READ_WRITE",
+					},
+				],
+				"can_ip_forward":      true,
+				"deletion_protection": false,
+				"description":         null,
+				"desired_status":      null,
+				"enable_display":      null,
+				"hostname":            null,
+				"labels":              null,
+				"machine_type":        "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "false",
+					"serial-port-enable":     "true",
+				},
+				"metadata_startup_script": "echo hi > /test.txt",
+				"name": "test",
+				"network_interface": [
+					{
+						"access_config": [
+							{
+								"public_ptr_domain_name": null,
+							},
+						],
+						"alias_ip_range": [],
+						"network":        "default",
+					},
+				],
+				"scratch_disk": [
+					{
+						"interface": "SCSI",
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+				"timeouts": null,
+				"zone":     "australia-southeast1-a",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance",
+	},
+	"google_compute_instance_template.this": {
+		"address": "google_compute_instance_template.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"can_ip_forward": false,
+				"description":    "This template is used to create app server instances.",
+				"disk": [
+					{
+						"auto_delete": true,
+						"boot":        true,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       null,
+						"source_image": "debian-cloud/debian-9",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "this",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "that",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "where",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "at",
+					},
+				],
+				"enable_display":       null,
+				"guest_accelerator":    [],
+				"instance_description": "description assigned to instances",
+				"labels": {
+					"environment": "dev",
+				},
+				"machine_type": "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "false",
+					"serial-port-enable":     "true",
+				},
+				"metadata_startup_script": null,
+				"min_cpu_platform":        null,
+				"name":                    "appserver-template",
+				"network_interface": [
+					{
+						"access_config":  [],
+						"alias_ip_range": [],
+						"network":        "default",
+						"network_ip":     null,
+					},
+				],
+				"scheduling": [
+					{
+						"automatic_restart":   true,
+						"node_affinities":     [],
+						"on_host_maintenance": "MIGRATE",
+						"preemptible":         false,
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance_template",
+	},
+}

--- a/gcp/compute/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances/testdata/mock-tfplan-success.sentinel
+++ b/gcp/compute/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,221 @@
+resource_changes = {
+	"google_compute_instance.this": {
+		"address": "google_compute_instance.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"allow_stopping_for_update": null,
+				"attached_disk": [
+					{
+						"disk_encryption_key_raw": null,
+						"kms_key_self_link":       "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+						"mode":                    "READ_WRITE",
+						"source":                  "this",
+					},
+					{
+						"disk_encryption_key_raw": null,
+						"mode":   "READ_WRITE",
+						"source": "that",
+					},
+				],
+				"boot_disk": [
+					{
+						"auto_delete":             true,
+						"disk_encryption_key_raw": null,
+						"initialize_params": [
+							{
+								"image": "debian-cloud/debian-9",
+							},
+						],
+						"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+						"mode":              "READ_WRITE",
+					},
+				],
+				"can_ip_forward":      false,
+				"deletion_protection": false,
+				"description":         null,
+				"desired_status":      null,
+				"enable_display":      null,
+				"hostname":            null,
+				"labels":              null,
+				"machine_type":        "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "true",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": "echo hi > /test.txt",
+				"name": "test",
+				"network_interface": [
+					{
+						"access_config": [
+							{
+								"public_ptr_domain_name": null,
+							},
+						],
+						"alias_ip_range": [],
+						"network":        "default",
+					},
+				],
+				"scratch_disk": [
+					{
+						"interface": "SCSI",
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+				"timeouts": null,
+				"zone":     "australia-southeast1-a",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance",
+	},
+	"google_compute_instance_template.this": {
+		"address": "google_compute_instance_template.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"can_ip_forward": false,
+				"description":    "This template is used to create app server instances.",
+				"disk": [
+					{
+						"auto_delete": true,
+						"boot":        true,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       null,
+						"source_image": "debian-cloud/debian-9",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "this",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "that",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "projects/tfe-multicloudinaction/locations/australia-southeast1/keyRings/tfe-multicloudinaction-ring/cryptoKeys/disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "where",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "at",
+					},
+				],
+				"enable_display":       null,
+				"guest_accelerator":    [],
+				"instance_description": "description assigned to instances",
+				"labels": {
+					"environment": "dev",
+				},
+				"machine_type": "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "true",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": null,
+				"min_cpu_platform":        null,
+				"name":                    "appserver-template",
+				"network_interface": [
+					{
+						"access_config":  [],
+						"alias_ip_range": [],
+						"network":        "default",
+						"network_ip":     null,
+					},
+				],
+				"scheduling": [
+					{
+						"automatic_restart":   true,
+						"node_affinities":     [],
+						"on_host_maintenance": "MIGRATE",
+						"preemptible":         false,
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance_template",
+	},
+}

--- a/gcp/compute/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys.sentinel
+++ b/gcp/compute/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys.sentinel
@@ -1,0 +1,76 @@
+import "tfplan/v2" as tfplan
+import "types"
+
+allComputeDisks = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_compute_disk" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+allComputeInstances = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_compute_instance" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+allComputeInstanceTemplates = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_compute_instance_template" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+getDiskEncryptionStatus = func(property) {
+	case  {
+		when types.type_of(property.disk_encryption_key_raw) is "null":
+			if keys(property) contains "kms_key_self_link" {
+				return length(property.kms_key_self_link) != 0
+			} else {
+				return false
+			}
+		when types.type_of(property.disk_encryption_key_raw) is "string":
+			return length(property.disk_encryption_key_raw) != 0
+		when types.type_of(property.disk_encryption_key) is "list":
+			return length(property.disk_encryption_key) != 0
+		else:
+			return false
+	}
+}
+
+print("CIS 4.6: Ensure VM disks for critical VMs are encrypted with Customer-Supplied Encryption Keys (CSEK)")
+
+disk_encryption_is_enabled_in_compute_disks = rule {
+	all allComputeDisks as _, disk {
+		length(disk.change.after.disk_encryption_key) > 0
+	}
+}
+
+disk_encryption_is_enabled_in_compute_instance_boot_disk = rule {
+	all allComputeInstances as _, instance {
+		all instance.change.after.boot_disk as _, boot_disk {
+			getDiskEncryptionStatus(boot_disk)
+		}
+	}
+}
+
+disk_encryption_is_enabled_in_compute_instance_attached_disk = rule {
+	all allComputeInstances as _, instance {
+		all instance.change.after.attached_disk as _, attached_disk {
+			getDiskEncryptionStatus(attached_disk)
+		}
+	}
+}
+
+disk_encryption_is_enabled_in_compute_instance_template_disk = rule {
+	all allComputeInstanceTemplates as _, template {
+		all template.change.after.disk as _, disk {
+			getDiskEncryptionStatus(disk)
+		}
+	}
+}
+
+main = rule {
+	disk_encryption_is_enabled_in_compute_disks and
+	disk_encryption_is_enabled_in_compute_instance_boot_disk and
+	disk_encryption_is_enabled_in_compute_instance_attached_disk and
+	disk_encryption_is_enabled_in_compute_instance_template_disk
+}

--- a/gcp/compute/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys/test/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys/failure.json
+++ b/gcp/compute/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys/test/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/compute/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys/test/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys/success.json
+++ b/gcp/compute/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys/test/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/compute/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/compute/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,633 @@
+resource_changes = {
+	"google_compute_disk.at": {
+		"address": "google_compute_disk.at",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description":                    null,
+				"disk_encryption_key":            [],
+				"image":                          null,
+				"labels":                         null,
+				"name":                           "at",
+				"size":                           1,
+				"snapshot":                       null,
+				"source_image_encryption_key":    [],
+				"source_snapshot_encryption_key": [],
+				"timeouts":                       null,
+				"type":                           "pd-standard",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "at",
+		"provider_name":  "google",
+		"type":           "google_compute_disk",
+	},
+	"google_compute_disk.that": {
+		"address": "google_compute_disk.that",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description":                    null,
+				"disk_encryption_key":            [],
+				"image":                          null,
+				"labels":                         null,
+				"name":                           "that",
+				"size":                           1,
+				"snapshot":                       null,
+				"source_image_encryption_key":    [],
+				"source_snapshot_encryption_key": [],
+				"timeouts":                       null,
+				"type":                           "pd-standard",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "that",
+		"provider_name":  "google",
+		"type":           "google_compute_disk",
+	},
+	"google_compute_disk.this": {
+		"address": "google_compute_disk.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": null,
+				"disk_encryption_key": [
+					{
+						"kms_key_self_link": "disk-crypto-key",
+						"raw_key":           null,
+					},
+				],
+				"image":                          null,
+				"labels":                         null,
+				"name":                           "this",
+				"size":                           1,
+				"snapshot":                       null,
+				"source_image_encryption_key":    [],
+				"source_snapshot_encryption_key": [],
+				"timeouts":                       null,
+				"type":                           "pd-standard",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_disk",
+	},
+	"google_compute_disk.where": {
+		"address": "google_compute_disk.where",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": null,
+				"disk_encryption_key": [
+					{
+						"kms_key_self_link": "disk-crypto-key",
+						"raw_key":           null,
+					},
+				],
+				"image":                          null,
+				"labels":                         null,
+				"name":                           "where",
+				"size":                           1,
+				"snapshot":                       null,
+				"source_image_encryption_key":    [],
+				"source_snapshot_encryption_key": [],
+				"timeouts":                       null,
+				"type":                           "pd-standard",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "where",
+		"provider_name":  "google",
+		"type":           "google_compute_disk",
+	},
+	"google_compute_instance.that": {
+		"address": "google_compute_instance.that",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"allow_stopping_for_update": null,
+				"attached_disk": [
+					{
+						"disk_encryption_key_raw": null,
+						"mode":   "READ_WRITE",
+						"source": "this",
+					},
+					{
+						"disk_encryption_key_raw": null,
+						"mode":   "READ_WRITE",
+						"source": "that",
+					},
+				],
+				"boot_disk": [
+					{
+						"auto_delete":             true,
+						"disk_encryption_key_raw": null,
+						"initialize_params": [
+							{
+								"image": "debian-cloud/debian-9",
+							},
+						],
+						"mode": "READ_WRITE",
+					},
+				],
+				"can_ip_forward":      false,
+				"deletion_protection": false,
+				"description":         null,
+				"desired_status":      null,
+				"enable_display":      null,
+				"hostname":            null,
+				"labels":              null,
+				"machine_type":        "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": "echo hi > /test.txt",
+				"name": "that",
+				"network_interface": [
+					{
+						"access_config": [
+							{
+								"public_ptr_domain_name": null,
+							},
+						],
+						"alias_ip_range": [],
+						"network":        "default",
+					},
+				],
+				"scratch_disk": [
+					{
+						"interface": "SCSI",
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+				"timeouts": null,
+				"zone":     "australia-southeast1-a",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "that",
+		"provider_name":  "google",
+		"type":           "google_compute_instance",
+	},
+	"google_compute_instance.this": {
+		"address": "google_compute_instance.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"allow_stopping_for_update": null,
+				"attached_disk": [
+					{
+						"disk_encryption_key_raw": null,
+						"mode":   "READ_WRITE",
+						"source": "this",
+					},
+					{
+						"disk_encryption_key_raw": null,
+						"mode":   "READ_WRITE",
+						"source": "that",
+					},
+				],
+				"boot_disk": [
+					{
+						"auto_delete":             true,
+						"disk_encryption_key_raw": null,
+						"initialize_params": [
+							{
+								"image": "debian-cloud/debian-9",
+							},
+						],
+						"mode": "READ_WRITE",
+					},
+				],
+				"can_ip_forward":      false,
+				"deletion_protection": false,
+				"description":         null,
+				"desired_status":      null,
+				"enable_display":      null,
+				"hostname":            null,
+				"labels":              null,
+				"machine_type":        "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": "echo hi > /test.txt",
+				"name": "test",
+				"network_interface": [
+					{
+						"access_config": [
+							{
+								"public_ptr_domain_name": null,
+							},
+						],
+						"alias_ip_range": [],
+						"network":        "default",
+					},
+				],
+				"scratch_disk": [
+					{
+						"interface": "SCSI",
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+				"timeouts": null,
+				"zone":     "australia-southeast1-a",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance",
+	},
+	"google_compute_instance.where": {
+		"address": "google_compute_instance.where",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"allow_stopping_for_update": null,
+				"attached_disk": [
+					{
+						"disk_encryption_key_raw": null,
+						"mode":   "READ_WRITE",
+						"source": "this",
+					},
+					{
+						"disk_encryption_key_raw": null,
+						"mode":   "READ_WRITE",
+						"source": "that",
+					},
+				],
+				"boot_disk": [
+					{
+						"auto_delete":             true,
+						"disk_encryption_key_raw": null,
+						"initialize_params": [
+							{
+								"image": "debian-cloud/debian-9",
+							},
+						],
+						"mode": "READ_WRITE",
+					},
+				],
+				"can_ip_forward":      false,
+				"deletion_protection": false,
+				"description":         null,
+				"desired_status":      null,
+				"enable_display":      null,
+				"hostname":            null,
+				"labels":              null,
+				"machine_type":        "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": "echo hi > /test.txt",
+				"name": "test",
+				"network_interface": [
+					{
+						"access_config": [
+							{
+								"public_ptr_domain_name": null,
+							},
+						],
+						"alias_ip_range": [],
+						"network":        "default",
+					},
+				],
+				"scratch_disk": [
+					{
+						"interface": "SCSI",
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+				"timeouts": null,
+				"zone":     "australia-southeast1-a",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "where",
+		"provider_name":  "google",
+		"type":           "google_compute_instance",
+	},
+	"google_compute_instance_template.that": {
+		"address": "google_compute_instance_template.that",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"can_ip_forward": false,
+				"description":    "This template is used to create app server instances.",
+				"disk": [
+					{
+						"auto_delete":         true,
+						"boot":                true,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              null,
+						"source_image":        "debian-cloud/debian-9",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "this",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "that",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "where",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "at",
+					},
+				],
+				"enable_display":       null,
+				"guest_accelerator":    [],
+				"instance_description": "description assigned to instances",
+				"labels": {
+					"environment": "dev",
+				},
+				"machine_type": "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": null,
+				"min_cpu_platform":        null,
+				"name":                    "appserver-template",
+				"network_interface": [
+					{
+						"access_config":  [],
+						"alias_ip_range": [],
+						"network":        "default",
+						"network_ip":     null,
+					},
+				],
+				"scheduling": [
+					{
+						"automatic_restart":   true,
+						"node_affinities":     [],
+						"on_host_maintenance": "MIGRATE",
+						"preemptible":         false,
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "that",
+		"provider_name":  "google",
+		"type":           "google_compute_instance_template",
+	},
+	"google_compute_instance_template.this": {
+		"address": "google_compute_instance_template.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"can_ip_forward": false,
+				"description":    "This template is used to create app server instances.",
+				"disk": [
+					{
+						"auto_delete":         true,
+						"boot":                true,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              null,
+						"source_image":        "debian-cloud/debian-9",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "this",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "that",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "where",
+					},
+					{
+						"auto_delete":         false,
+						"boot":                false,
+						"disk_encryption_key": [],
+						"disk_name":           null,
+						"disk_size_gb":        null,
+						"labels":              null,
+						"source":              "at",
+					},
+				],
+				"enable_display":       null,
+				"guest_accelerator":    [],
+				"instance_description": "description assigned to instances",
+				"labels": {
+					"environment": "dev",
+				},
+				"machine_type": "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": null,
+				"min_cpu_platform":        null,
+				"name":                    "appserver-template",
+				"network_interface": [
+					{
+						"access_config":  [],
+						"alias_ip_range": [],
+						"network":        "default",
+						"network_ip":     null,
+					},
+				],
+				"scheduling": [
+					{
+						"automatic_restart":   true,
+						"node_affinities":     [],
+						"on_host_maintenance": "MIGRATE",
+						"preemptible":         false,
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance_template",
+	},
+}

--- a/gcp/compute/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys/testdata/mock-tfplan-success.sentinel
+++ b/gcp/compute/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,689 @@
+resource_changes = {
+	"google_compute_disk.at": {
+		"address": "google_compute_disk.at",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": null,
+				"disk_encryption_key": [
+					{
+						"kms_key_self_link": "disk-crypto-key",
+						"raw_key":           null,
+					},
+				],
+				"image":                          null,
+				"labels":                         null,
+				"name":                           "at",
+				"size":                           1,
+				"snapshot":                       null,
+				"source_image_encryption_key":    [],
+				"source_snapshot_encryption_key": [],
+				"timeouts":                       null,
+				"type":                           "pd-standard",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "at",
+		"provider_name":  "google",
+		"type":           "google_compute_disk",
+	},
+	"google_compute_disk.that": {
+		"address": "google_compute_disk.that",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": null,
+				"disk_encryption_key": [
+					{
+						"kms_key_self_link": "disk-crypto-key",
+						"raw_key":           null,
+					},
+				],
+				"image":                          null,
+				"labels":                         null,
+				"name":                           "that",
+				"size":                           1,
+				"snapshot":                       null,
+				"source_image_encryption_key":    [],
+				"source_snapshot_encryption_key": [],
+				"timeouts":                       null,
+				"type":                           "pd-standard",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "that",
+		"provider_name":  "google",
+		"type":           "google_compute_disk",
+	},
+	"google_compute_disk.this": {
+		"address": "google_compute_disk.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": null,
+				"disk_encryption_key": [
+					{
+						"kms_key_self_link": "disk-crypto-key",
+						"raw_key":           null,
+					},
+				],
+				"image":                          null,
+				"labels":                         null,
+				"name":                           "this",
+				"size":                           1,
+				"snapshot":                       null,
+				"source_image_encryption_key":    [],
+				"source_snapshot_encryption_key": [],
+				"timeouts":                       null,
+				"type":                           "pd-standard",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_disk",
+	},
+	"google_compute_disk.where": {
+		"address": "google_compute_disk.where",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": null,
+				"disk_encryption_key": [
+					{
+						"kms_key_self_link": "disk-crypto-key",
+						"raw_key":           null,
+					},
+				],
+				"image":                          null,
+				"labels":                         null,
+				"name":                           "where",
+				"size":                           1,
+				"snapshot":                       null,
+				"source_image_encryption_key":    [],
+				"source_snapshot_encryption_key": [],
+				"timeouts":                       null,
+				"type":                           "pd-standard",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "where",
+		"provider_name":  "google",
+		"type":           "google_compute_disk",
+	},
+	"google_compute_instance.that": {
+		"address": "google_compute_instance.that",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"allow_stopping_for_update": null,
+				"attached_disk": [
+					{
+						"disk_encryption_key_raw": null,
+						"kms_key_self_link":       "disk-crypto-key",
+						"mode":                    "READ_WRITE",
+						"source":                  "this",
+					},
+					{
+						"disk_encryption_key_raw": null,
+						"kms_key_self_link":       "disk-crypto-key",
+						"mode":                    "READ_WRITE",
+						"source":                  "this",
+					},
+				],
+				"boot_disk": [
+					{
+						"auto_delete":             true,
+						"disk_encryption_key_raw": null,
+						"initialize_params": [
+							{
+								"image": "debian-cloud/debian-9",
+							},
+						],
+						"kms_key_self_link": "disk-crypto-key",
+						"mode":              "READ_WRITE",
+					},
+				],
+				"can_ip_forward":      false,
+				"deletion_protection": false,
+				"description":         null,
+				"desired_status":      null,
+				"enable_display":      null,
+				"hostname":            null,
+				"labels":              null,
+				"machine_type":        "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": "echo hi > /test.txt",
+				"name": "that",
+				"network_interface": [
+					{
+						"access_config": [
+							{
+								"public_ptr_domain_name": null,
+							},
+						],
+						"alias_ip_range": [],
+						"network":        "default",
+					},
+				],
+				"scratch_disk": [
+					{
+						"interface": "SCSI",
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+				"timeouts": null,
+				"zone":     "australia-southeast1-a",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "that",
+		"provider_name":  "google",
+		"type":           "google_compute_instance",
+	},
+	"google_compute_instance.this": {
+		"address": "google_compute_instance.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"allow_stopping_for_update": null,
+				"attached_disk": [
+					{
+						"disk_encryption_key_raw": null,
+						"kms_key_self_link":       "disk-crypto-key",
+						"mode":                    "READ_WRITE",
+						"source":                  "this",
+					},
+					{
+						"disk_encryption_key_raw": null,
+						"kms_key_self_link":       "disk-crypto-key",
+						"mode":                    "READ_WRITE",
+						"source":                  "this",
+					},
+				],
+				"boot_disk": [
+					{
+						"auto_delete":             true,
+						"disk_encryption_key_raw": null,
+						"initialize_params": [
+							{
+								"image": "debian-cloud/debian-9",
+							},
+						],
+						"kms_key_self_link": "disk-crypto-key",
+						"mode":              "READ_WRITE",
+					},
+				],
+				"can_ip_forward":      false,
+				"deletion_protection": false,
+				"description":         null,
+				"desired_status":      null,
+				"enable_display":      null,
+				"hostname":            null,
+				"labels":              null,
+				"machine_type":        "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": "echo hi > /test.txt",
+				"name": "test",
+				"network_interface": [
+					{
+						"access_config": [
+							{
+								"public_ptr_domain_name": null,
+							},
+						],
+						"alias_ip_range": [],
+						"network":        "default",
+					},
+				],
+				"scratch_disk": [
+					{
+						"interface": "SCSI",
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+				"timeouts": null,
+				"zone":     "australia-southeast1-a",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance",
+	},
+	"google_compute_instance.where": {
+		"address": "google_compute_instance.where",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"allow_stopping_for_update": null,
+				"attached_disk": [
+					{
+						"disk_encryption_key_raw": "some-string",
+						"mode":   "READ_WRITE",
+						"source": "this",
+					},
+					{
+						"disk_encryption_key_raw": "some-string",
+						"mode":   "READ_WRITE",
+						"source": "this",
+					},
+				],
+				"boot_disk": [
+					{
+						"auto_delete":             true,
+						"disk_encryption_key_raw": "some-string",
+						"initialize_params": [
+							{
+								"image": "debian-cloud/debian-9",
+							},
+						],
+						"mode": "READ_WRITE",
+					},
+				],
+				"can_ip_forward":      false,
+				"deletion_protection": false,
+				"description":         null,
+				"desired_status":      null,
+				"enable_display":      null,
+				"hostname":            null,
+				"labels":              null,
+				"machine_type":        "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": "echo hi > /test.txt",
+				"name": "test",
+				"network_interface": [
+					{
+						"access_config": [
+							{
+								"public_ptr_domain_name": null,
+							},
+						],
+						"alias_ip_range": [],
+						"network":        "default",
+					},
+				],
+				"scratch_disk": [
+					{
+						"interface": "SCSI",
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+				"timeouts": null,
+				"zone":     "australia-southeast1-a",
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "where",
+		"provider_name":  "google",
+		"type":           "google_compute_instance",
+	},
+	"google_compute_instance_template.that": {
+		"address": "google_compute_instance_template.that",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"can_ip_forward": false,
+				"description":    "This template is used to create app server instances.",
+				"disk": [
+					{
+						"auto_delete": true,
+						"boot":        true,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       null,
+						"source_image": "debian-cloud/debian-9",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "this",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "that",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "where",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "at",
+					},
+				],
+				"enable_display":       null,
+				"guest_accelerator":    [],
+				"instance_description": "description assigned to instances",
+				"labels": {
+					"environment": "dev",
+				},
+				"machine_type": "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": null,
+				"min_cpu_platform":        null,
+				"name":                    "appserver-template",
+				"network_interface": [
+					{
+						"access_config":  [],
+						"alias_ip_range": [],
+						"network":        "default",
+						"network_ip":     null,
+					},
+				],
+				"scheduling": [
+					{
+						"automatic_restart":   true,
+						"node_affinities":     [],
+						"on_host_maintenance": "MIGRATE",
+						"preemptible":         false,
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "that",
+		"provider_name":  "google",
+		"type":           "google_compute_instance_template",
+	},
+	"google_compute_instance_template.this": {
+		"address": "google_compute_instance_template.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"can_ip_forward": false,
+				"description":    "This template is used to create app server instances.",
+				"disk": [
+					{
+						"auto_delete": true,
+						"boot":        true,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       null,
+						"source_image": "debian-cloud/debian-9",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "this",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "that",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "where",
+					},
+					{
+						"auto_delete": false,
+						"boot":        false,
+						"disk_encryption_key": [
+							{
+								"kms_key_self_link": "disk-crypto-key",
+							},
+						],
+						"disk_name":    null,
+						"disk_size_gb": null,
+						"labels":       null,
+						"source":       "at",
+					},
+				],
+				"enable_display":       null,
+				"guest_accelerator":    [],
+				"instance_description": "description assigned to instances",
+				"labels": {
+					"environment": "dev",
+				},
+				"machine_type": "n1-standard-1",
+				"metadata": {
+					"block-project-ssh-keys": "false",
+					"enable-oslogin":         "true",
+					"serial-port-enable":     "false",
+				},
+				"metadata_startup_script": null,
+				"min_cpu_platform":        null,
+				"name":                    "appserver-template",
+				"network_interface": [
+					{
+						"access_config":  [],
+						"alias_ip_range": [],
+						"network":        "default",
+						"network_ip":     null,
+					},
+				],
+				"scheduling": [
+					{
+						"automatic_restart":   true,
+						"node_affinities":     [],
+						"on_host_maintenance": "MIGRATE",
+						"preemptible":         false,
+					},
+				],
+				"service_account": [
+					{
+						"scopes": [
+							"https://www.googleapis.com/auth/compute.readonly",
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/userinfo.email",
+						],
+					},
+				],
+				"shielded_instance_config": [],
+				"tags": [
+					"bar",
+					"foo",
+				],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google",
+		"type":           "google_compute_instance_template",
+	},
+}


### PR DESCRIPTION
This PR provides Sentinel policies that follow the security recommendations that are provided in the CIS Google Cloud Computing Platform Foundations Benchmark v.1.0.0, namely:

## CIS 4.2: Ensure "Block Project-wide SSH keys" enabled for VM instances

### Description
Project-wide SSH keys are stored in Compute/Project-meta-data. Project wide SSH keys can be used to login into all the instances within project. Using project-wide SSH keys eases the SSH key management but if compromised, poses the security risk which can impact all the instances within project. It is recommended to use Instance specific SSH keys which can limit the attack surface if the SSH keys are compromised.

### Configuration

```hcl
policy "gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/compute/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances.sentinel"
    enforcement_level = "advisory"
}
```
## CIS 4.3: Ensure oslogin is enabled for a Project

### Description
Enabling osLogin ensures that SSH keys used to connect to instances are mapped with IAM users. Revoking access to IAM user will revoke all the SSH keys associated with that particular user. It facilitates centralized and automated SSH key pair management which is useful in handling cases like response to compromised SSH key pairs and/or revocation of external/third-party/Vendor users.

### Configuration

```hcl
policy "gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/compute/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 4.4: Ensure 'Enable connecting to serial ports' is not enabled for VM Instance

### Description
If you enable the interactive serial console on an instance, clients can attempt to connect to that instance from any IP address. Therefore interactive serial console support should be disabled.

### Configuration
```hcl
policy "gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/compute/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 4.5: Ensure that IP forwarding is not enabled on Instances

### Description
Compute Engine instance cannot forward a packet unless the source IP address of the packet matches the IP address of the instance. Similarly, GCP won't deliver a packet whose destination IP address is different than the IP address of the instance receiving the packet. However, both capabilities are required if you want to use instances to help route packets. Forwarding of data packets should be disabled to prevent data loss or information disclosure.

### Configuration

```hcl
policy "gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/compute/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances/gcp-cis-4.5-compute-ensure-that-ip-forwarding-is-not-enabled-on-instances.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 4.6: Ensure VM disks for critical VMs are encrypted with Customer- Supplied Encryption Keys (CSEK)

### Description
If you provide your own encryption keys, Compute Engine uses your key to protect the Google-generated keys used to encrypt and decrypt your data. Only users who can provide the correct key can use resources protected by a customer-supplied encryption key. Google does not store your keys on its servers and cannot access your protected data unless you provide the key.

> **Note:**
If you forget or lose your key, there is no way for Google to recover the key or to recover any data encrypted with the lost key.

### Configuration

```hcl
policy "gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/compute/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys/gcp-cis-4.6-compute-ensure-vm-disks-for-critical-vms-are-encrypted-with-customer-supplied-encryption-keys.sentinel"
    enforcement_level = "advisory"
}
```