### PR TITLE
Adding GCP CIS Kubernetes Policy Configuration

### DIFF
--- a/gcp/kubernetes/README.md
+++ b/gcp/kubernetes/README.md
@@ -1,0 +1,212 @@
+#  CIS Google Cloud Computing Foundational Sentinel policies
+
+The following code snippets show the configuration settings that are required to successfully deploy Sentinel policies that follow the security recommendations that are provided in the [CIS Google Cloud Computing Platform Foundations Benchmark v.1.0.0](https://www.cisecurity.org/benchmark/google_cloud_computing_platform/). We cover policy configuration in more details in the [Managing Sentinel Policies](https://www.terraform.io/docs/cloud/sentinel/manage-policies.html) section in the Terraform Cloud [documentation](https://www.terraform.io/docs/cloud/index.html).
+
+## CIS 7.1: Ensure Stackdriver Logging is set to Enabled on Kubernetes Engine Clusters
+
+### Description
+Stackdriver Logging is part of the Stackdriver suite of products in Google Cloud Platform. It includes storage for logs, a user interface called the Logs Viewer, and an API to manage logs programmatically. Stackdriver Logging lets you have Kubernetes Engine automatically collect, process, and store your container and system logs in a dedicated, persistent datastore. Container logs are collected from your containers. System logs are collected from the cluster's components, such as docker and kubelet. Events are logs about activity in the cluster, such as the scheduling of Pods.
+
+### Configuration
+
+```hcl
+policy "gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 7.2: Ensure Stackdriver Monitoring is set to Enabled on Kubernetes Engine Clusters
+
+### Description
+Stackdriver Monitoring to monitor signals and build operations in your Kubernetes Engine clusters. Stackdriver Monitoring can access metrics about CPU utilization, some disk traffic metrics, network traffic, and uptime information. Stackdriver Monitoring uses the Monitoring agent to access additional system resources and application services in virtual machine instances.
+
+### Configuration
+```hcl
+policy "gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 7.3: Ensure Legacy Authorization is set to Disabled on Kubernetes Engine Clusters
+
+### Description
+In Kubernetes, authorizers interact by granting a permission if any authorizer grants the permission. The legacy authorizer in Kubernetes Engine grants broad, statically defined permissions. To ensure that RBAC limits permissions correctly, you must disable the legacy authorizer. RBAC has significant security advantages, can help you ensure that users only have access to cluster resources within their own namespace and is now stable in Kubernetes.
+
+### Configuration
+```hcl
+policy "gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 7.4: Ensure Master authorized networks is set to Enabled on Kubernetes Engine Clusters
+
+### Description
+Authorized networks are a way of specifying a restricted range of IP addresses that are permitted to access your container cluster's Kubernetes master endpoint. Kubernetes Engine uses both Transport Layer Security (TLS) and authentication to provide secure access to your container cluster's Kubernetes master endpoint from the public internet. This provides you the flexibility to administer your cluster from anywhere; however, you might want to further restrict access to a set of IP addresses that you control. You can set this restriction by specifying an authorized network.
+
+### Configuration
+```hcl
+policy "gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 7.5: Ensure Kubernetes Clusters are configured with Labels
+
+### Description
+A cluster label is a key-value pair that helps you organize your Google Cloud Platform resources, such as clusters. You can attach a label to each resource, then filter the resources based on their labels. Information about labels is forwarded to the billing system, so you can break down your billing charges by the label.
+
+### Configuration
+```hcl
+policy "gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 7.7: Ensure Automatic node repair is enabled for Kubernetes Clusters
+
+### Description
+Kubernetes Engine's node auto-repair feature helps you keep the nodes in your cluster in a healthy, running state. When enabled, Kubernetes Engine makes periodic checks on the health state of each node in your cluster. If a node fails consecutive health checks over an extended time period, Kubernetes Engine initiates a repair process for that node. If you disable node auto-repair at any time during the repair process, the in-progress repairs are not cancelled and still complete for any node currently under repair.
+
+### Configuration
+```hcl
+policy "gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 7.8: Ensure Automatic node upgrades is enabled on Kubernetes Engine Clusters nodes
+
+### Description
+Node auto-upgrades help you keep the nodes in your cluster or node pool up to date with the latest stable version of Kubernetes. Auto-Upgrades use the same update mechanism as manual node upgrades.
+
+### Configuration
+```hcl
+policy "gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 7.9: Ensure Container-Optimized OS (cos) is used for Kubernetes Engine Clusters Node image
+
+### Description
+Container-Optimized OS is an operating system image for your Compute Engine VMs that is optimized for running Docker containers. With Container-Optimized OS, you can bring up your Docker containers on Google Cloud Platform quickly, efficiently, and securely.
+
+### Configuration
+```hcl
+policy "gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 7.10: Ensure Basic Authentication is disabled on Kubernetes Engine Clusters
+
+### Description
+Basic authentication allows a user to authenticate to the cluster with a username and password and it is stored in plain text without any encryption. Disabling Basic authentication will prevent attacks like brute force. Its recommended to use either client certificate or IAM for authentication.
+
+### Configuration
+```hcl
+policy "gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 7.11: Ensure Network policy is enabled on Kubernetes Engine Clusters
+
+### Description
+A network policy is a specification of how groups of pods are allowed to communicate with each other and other network endpoints. NetworkPolicy resources use labels to select pods and define rules which specify what traffic is allowed to the selected pods. The Kubernetes Network Policy API allows the cluster administrator to specify what pods are allowed to communicate with each other.
+
+### Configuration
+```hcl
+policy "gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 7.12: Ensure Kubernetes Cluster is created with Client Certificate enabled
+
+### Description
+If you disable client certificate generation to create a cluster without a client certificate. You will still be able to authenticate to the cluster with basic auth or IAM. But basic auth allows a user to authenticate to the cluster with a username and password which are stored in plain text without any encryption and might lead brute force attacks.
+
+### Configuration
+```hcl
+policy "gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 7.13: Ensure Kubernetes Cluster is created with Alias IP ranges enabled
+
+### Description
+Google Cloud Platform Alias IP Ranges lets you assign ranges of internal IP addresses as aliases to a virtual machine's network interfaces. This is useful if you have multiple services running on a VM and you want to assign each service a different IP address.
+
+### Configuration
+```hcl
+policy "gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 7.14: Ensure PodSecurityPolicy controller is enabled on the Kubernetes Engine Clusters
+
+### Description
+A Pod Security Policy is a cluster-level resource that controls security sensitive aspects of the pod specification. The PodSecurityPolicy objects define a set of conditions that a pod must run with in order to be accepted into the system, as well as defaults for the related fields.
+
+### Configuration
+```hcl
+policy "gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 7.15: Ensure Kubernetes Cluster is created with Private cluster enabled
+
+### Description
+A private cluster is a cluster that makes your master inaccessible from the public internet. In a private cluster, nodes do not have public IP addresses, so your workloads run in an environment that is isolated from the internet. Nodes have addressed only in the private RFC 1918 address space. Nodes and masters communicate with each other privately using VPC peering.
+
+### Configuration
+```hcl
+policy "gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 7.17: Ensure default Service account is not used for Project access in Kubernetes Clusters
+
+### Description
+A service account is an identity that an instance or an application can use to run API requests on your behalf. This identity is used to identify applications running on your virtual machine instances to other Google Cloud Platform services. By default, Kubernetes Engine nodes are given the Compute Engine default service account. This account has broad access by default, making it useful to a wide variety of applications, but it has more permissions than are required to run your Kubernetes Engine cluster.
+
+### Configuration
+```hcl
+policy "gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters.sentinel"
+    enforcement_level = "advisory"
+}
+```
+
+## CIS 7.18: Ensure Kubernetes Clusters created with limited service account Access scopes for Project access
+
+### Description
+Access scopes are the legacy method of specifying permissions for your instance. Before the existence of IAM roles, access scopes were the only mechanism for granting permissions to service accounts. By default, your node service account has access scopes.
+
+### Configuration
+```hcl
+policy "gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access" {
+    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access.sentinel"
+    enforcement_level = "advisory"
+}
+```

--- a/gcp/kubernetes/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters.sentinel
@@ -1,0 +1,24 @@
+import "tfplan/v2" as tfplan
+
+supportedLoggingServices = [
+	"logging.googleapis.com/kubernetes",
+	"logging.googleapis.com",
+]
+
+allContainerClusters = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_cluster" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 7.1: Ensure Stackdriver Logging is set to Enabled on Kubernetes Engine Clusters")
+
+logging_service_is_enabled = rule {
+	all allContainerClusters as _, cluster {
+		cluster.change.after.logging_service in supportedLoggingServices
+	}
+}
+
+main = rule {
+	logging_service_is_enabled
+}

--- a/gcp/kubernetes/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters/test/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters/failure.json
+++ b/gcp/kubernetes/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters/test/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters/test/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters/success.json
+++ b/gcp/kubernetes/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters/test/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    null,
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": "monitoring.googleapis.com/kubernetes",
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-success.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    "logging.googleapis.com/kubernetes",
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": "monitoring.googleapis.com/kubernetes",
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters.sentinel
@@ -1,0 +1,22 @@
+import "tfplan/v2" as tfplan
+
+allContainerClusters = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_cluster" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 7.10: Ensure Basic Authentication is disabled on Kubernetes Engine Clusters")
+
+basic_authentication_is_disabled = rule {
+	all allContainerClusters as _, cluster {
+		all cluster.change.after.master_auth as _, master_auth {
+			keys(master_auth) not contains "username" and
+				keys(master_auth) not contains "password"
+		}
+	}
+}
+
+main = rule {
+	basic_authentication_is_disabled
+}

--- a/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/test/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/failure.json
+++ b/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/test/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/test/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/success.json
+++ b/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/test/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    null,
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": null,
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-success.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,186 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    "logging.googleapis.com/kubernetes",
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": "monitoring.googleapis.com/kubernetes",
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters.sentinel
@@ -1,0 +1,21 @@
+import "tfplan/v2" as tfplan
+
+allContainerClusters = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_cluster" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 7.11: Ensure Network policy is enabled on Kubernetes Engine Clusters")
+
+network_policy_is_enabled = rule {
+	all allContainerClusters as _, cluster {
+		all cluster.change.after.network_policy as _, network_policy {
+			network_policy.enabled is true
+		}
+	}
+}
+
+main = rule {
+	network_policy_is_enabled
+}

--- a/gcp/kubernetes/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters/test/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters/failure.json
+++ b/gcp/kubernetes/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters/test/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters/test/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters/success.json
+++ b/gcp/kubernetes/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters/test/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    null,
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": null,
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  false,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-success.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    "logging.googleapis.com/kubernetes",
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": "monitoring.googleapis.com/kubernetes",
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled.sentinel
@@ -1,0 +1,23 @@
+import "tfplan/v2" as tfplan
+
+allContainerClusters = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_cluster" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 7.12: Ensure Kubernetes Cluster is created with Client Certificate enabled")
+
+client_certificate_is_enabled = rule {
+	all allContainerClusters as _, cluster {
+		all cluster.change.after.master_auth as _, master_auth {
+			all master_auth.client_certificate_config as _, client_certificate_config {
+				client_certificate_config.issue_client_certificate is true
+			}
+		}
+	}
+}
+
+main = rule {
+	client_certificate_is_enabled
+}

--- a/gcp/kubernetes/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled/test/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled/failure.json
+++ b/gcp/kubernetes/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled/test/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled/test/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled/success.json
+++ b/gcp/kubernetes/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled/test/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    null,
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": false,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": null,
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled/testdata/mock-tfplan-success.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    "logging.googleapis.com/kubernetes",
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": "monitoring.googleapis.com/kubernetes",
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled.sentinel
@@ -1,0 +1,20 @@
+import "tfplan/v2" as tfplan
+
+allContainerClusters = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_cluster" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 7.13: Ensure Kubernetes Cluster is created with Alias IP ranges enabled")
+
+cluster_alias_ip_ranges_is_enabled = rule {
+	all allContainerClusters as _, cluster {
+		keys(cluster.change.after) contains "ip_allocation_policy" and
+			length(cluster.change.after.ip_allocation_policy) > 0
+	}
+}
+
+main = rule {
+	cluster_alias_ip_ranges_is_enabled
+}

--- a/gcp/kubernetes/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled/test/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled/failure.json
+++ b/gcp/kubernetes/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled/test/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled/test/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled/success.json
+++ b/gcp/kubernetes/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled/test/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,183 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy":        [],
+				"location":                    "australia-southeast1",
+				"logging_service":             null,
+				"maintenance_policy":          [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": null,
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled/testdata/mock-tfplan-success.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    "logging.googleapis.com/kubernetes",
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": "monitoring.googleapis.com/kubernetes",
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters.sentinel
@@ -1,0 +1,21 @@
+import "tfplan/v2" as tfplan
+
+allContainerClusters = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_cluster" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 7.14: Ensure PodSecurityPolicy controller is enabled on the Kubernetes Engine Clusters")
+
+pod_security_policy_controller_is_enabled = rule {
+	all allContainerClusters as _, cluster {
+		all cluster.change.after.pod_security_policy_config as _, pod_security_policy_config {
+			pod_security_policy_config.enabled is true
+		}
+	}
+}
+
+main = rule {
+	pod_security_policy_controller_is_enabled
+}

--- a/gcp/kubernetes/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters/test/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters/failure.json
+++ b/gcp/kubernetes/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters/test/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters/test/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters/success.json
+++ b/gcp/kubernetes/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters/test/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    null,
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": null,
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": false,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters/testdata/mock-tfplan-success.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    "logging.googleapis.com/kubernetes",
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": "monitoring.googleapis.com/kubernetes",
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled.sentinel
@@ -1,0 +1,20 @@
+import "tfplan/v2" as tfplan
+
+allContainerClusters = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_cluster" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 7.15: Ensure Kubernetes Cluster is created with Private cluster enabled")
+
+private_cluster_config_is_enabled = rule {
+	all allContainerClusters as _, cluster {
+		keys(cluster.change.after) contains "private_cluster_config" and
+			length(cluster.change.after.private_cluster_config) > 0
+	}
+}
+
+main = rule {
+	private_cluster_config_is_enabled
+}

--- a/gcp/kubernetes/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled/test/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled/failure.json
+++ b/gcp/kubernetes/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled/test/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled/test/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled/success.json
+++ b/gcp/kubernetes/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled/test/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,182 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    null,
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": null,
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config":       [],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled/testdata/mock-tfplan-success.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    "logging.googleapis.com/kubernetes",
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": "monitoring.googleapis.com/kubernetes",
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters.sentinel
@@ -1,0 +1,36 @@
+import "tfplan/v2" as tfplan
+
+allContainerClusters = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_cluster" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+allNodePools = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_node_pool" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 7.17: Ensure default Service account is not used for Project access in Kubernetes Clusters")
+
+cluster_service_account_is_enabled = rule {
+	all allContainerClusters as _, cluster {
+		all cluster.change.after.node_config as _, node_config {
+			keys(node_config) contains "service_account"
+		}
+	}
+}
+
+pool_service_account_is_enabled = rule {
+	all allNodePools as _, pool {
+		all pool.change.after.node_config as _, node_config {
+			keys(node_config) contains "service_account"
+		}
+	}
+}
+
+main = rule {
+	cluster_service_account_is_enabled and
+	pool_service_account_is_enabled
+}

--- a/gcp/kubernetes/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters/test/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters/failure.json
+++ b/gcp/kubernetes/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters/test/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters/test/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters/success.json
+++ b/gcp/kubernetes/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters/test/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,186 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    null,
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": null,
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":    true,
+						"sandbox_config": [],
+						"tags":           null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":    true,
+						"sandbox_config": [],
+						"tags":           null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters/testdata/mock-tfplan-success.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    "logging.googleapis.com/kubernetes",
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": "monitoring.googleapis.com/kubernetes",
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access.sentinel
@@ -1,0 +1,49 @@
+import "tfplan/v2" as tfplan
+
+supportedAccessScopes = [
+	"https://www.googleapis.com/auth/logging.write",
+	"https://www.googleapis.com/auth/monitoring",
+	"https://www.googleapis.com/auth/devstorage.read_only",
+	"storage-ro",
+	"logging-write",
+	"monitoring",
+]
+
+allContainerClusters = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_cluster" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+allNodePools = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_node_pool" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 7.18: Ensure Kubernetes Clusters created with limited service account Access scopes for Project access")
+
+cluster_supported_access_scope_is_configured = rule {
+	all allContainerClusters as _, cluster {
+		all cluster.change.after.node_config as _, node_config {
+			all node_config.oauth_scopes as oauth_scopes {
+				oauth_scopes in supportedAccessScopes
+			}
+		}
+	}
+}
+
+pool_supported_access_scope_is_configured = rule {
+	all allNodePools as _, pool {
+		all pool.change.after.node_config as _, node_config {
+			all node_config.oauth_scopes as oauth_scopes {
+				oauth_scopes in supportedAccessScopes
+			}
+		}
+	}
+}
+
+main = rule {
+	cluster_supported_access_scope_is_configured and
+	pool_supported_access_scope_is_configured
+}

--- a/gcp/kubernetes/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access/test/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access/failure.json
+++ b/gcp/kubernetes/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access/test/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access/test/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access/success.json
+++ b/gcp/kubernetes/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access/test/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,190 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    null,
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": null,
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+							"https://www.googleapis.com/auth/servicecontrol",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+							"https://www.googleapis.com/auth/servicecontrol",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access/testdata/mock-tfplan-success.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    "logging.googleapis.com/kubernetes",
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": "monitoring.googleapis.com/kubernetes",
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters.sentinel
@@ -1,0 +1,24 @@
+import "tfplan/v2" as tfplan
+
+supportedMonitoringServices = [
+	"monitoring.googleapis.com/kubernetes",
+	"monitoring.googleapis.com",
+]
+
+allContainerClusters = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_cluster" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 7.2: Ensure Stackdriver Monitoring is set to Enabled on Kubernetes Engine Clusters")
+
+monitoring_service_is_enabled = rule {
+	all allContainerClusters as _, cluster {
+		cluster.change.after.monitoring_service in supportedMonitoringServices
+	}
+}
+
+main = rule {
+	monitoring_service_is_enabled
+}

--- a/gcp/kubernetes/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters/test/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters/failure.json
+++ b/gcp/kubernetes/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters/test/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters/test/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters/success.json
+++ b/gcp/kubernetes/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters/test/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    null,
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": null,
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-success.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    "logging.googleapis.com/kubernetes",
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": "monitoring.googleapis.com/kubernetes",
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters.sentinel
@@ -1,0 +1,19 @@
+import "tfplan/v2" as tfplan
+
+allContainerClusters = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_cluster" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 7.3: Ensure Legacy Authorization is set to Disabled on Kubernetes Engine Clusters")
+
+enable_legacy_abac_is_disabled = rule {
+	all allContainerClusters as _, cluster {
+		cluster.change.after.enable_legacy_abac is false
+	}
+}
+
+main = rule {
+	enable_legacy_abac_is_disabled
+}

--- a/gcp/kubernetes/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters/test/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters/failure.json
+++ b/gcp/kubernetes/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters/test/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters/test/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters/success.json
+++ b/gcp/kubernetes/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters/test/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          true,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    null,
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": null,
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-success.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    "logging.googleapis.com/kubernetes",
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": "monitoring.googleapis.com/kubernetes",
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters.sentinel
@@ -1,0 +1,19 @@
+import "tfplan/v2" as tfplan
+
+allContainerClusters = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_cluster" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 7.4: Ensure Master authorized networks is set to Enabled on Kubernetes Engine Clusters")
+
+master_authorized_networks_config_is_configured = rule {
+	all allContainerClusters as _, cluster {
+		length(cluster.change.after.master_authorized_networks_config) > 0
+	}
+}
+
+main = rule {
+	master_authorized_networks_config_is_configured
+}

--- a/gcp/kubernetes/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters/test/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters/failure.json
+++ b/gcp/kubernetes/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters/test/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters/test/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters/success.json
+++ b/gcp/kubernetes/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters/test/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,171 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    null,
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [],
+				"min_master_version":                null,
+				"monitoring_service":                null,
+				"name":                              "this-cluster",
+				"network":                           "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-success.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    "logging.googleapis.com/kubernetes",
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": "monitoring.googleapis.com/kubernetes",
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels.sentinel
@@ -1,0 +1,36 @@
+import "tfplan/v2" as tfplan
+
+allContainerClusters = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_cluster" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+allNodePools = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_node_pool" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 7.5: Ensure Kubernetes Clusters are configured with Labels")
+
+cluster_node_config_is_labelled = rule {
+	all allContainerClusters as _, cluster {
+		all cluster.change.after.node_config as _, node_config {
+			keys(node_config) contains "labels"
+		}
+	}
+}
+
+pool_node_config_is_labelled = rule {
+	all allNodePools as _, pool {
+		all pool.change.after.node_config as _, node_config {
+			keys(node_config) contains "labels"
+		}
+	}
+}
+
+main = rule {
+	cluster_node_config_is_labelled and
+	pool_node_config_is_labelled
+}

--- a/gcp/kubernetes/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels/test/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels/failure.json
+++ b/gcp/kubernetes/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels/test/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels/test/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels/success.json
+++ b/gcp/kubernetes/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels/test/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,182 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    null,
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": null,
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"machine_type":      "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"machine_type":      "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels/testdata/mock-tfplan-success.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    "logging.googleapis.com/kubernetes",
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": "monitoring.googleapis.com/kubernetes",
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters.sentinel
@@ -1,0 +1,21 @@
+import "tfplan/v2" as tfplan
+
+allNodePools = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_node_pool" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 7.7: Ensure `Automatic node repair` is enabled for Kubernetes Clusters")
+
+node_auto_repair_is_enabled = rule {
+	all allNodePools as _, pool {
+		all pool.change.after.management as _, management {
+			management.auto_repair is true
+		}
+	}
+}
+
+main = rule {
+	node_auto_repair_is_enabled
+}

--- a/gcp/kubernetes/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters/test/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters/failure.json
+++ b/gcp/kubernetes/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters/test/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters/test/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters/success.json
+++ b/gcp/kubernetes/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters/test/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    null,
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": null,
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  false,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters/testdata/mock-tfplan-success.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    "logging.googleapis.com/kubernetes",
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": "monitoring.googleapis.com/kubernetes",
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes.sentinel
@@ -1,0 +1,21 @@
+import "tfplan/v2" as tfplan
+
+allNodePools = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_node_pool" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 7.8: Ensure Automatic node upgrades is enabled on Kubernetes Engine Clusters nodes")
+
+node_auto_upgrade_is_enabled = rule {
+	all allNodePools as _, pool {
+		all pool.change.after.management as _, management {
+			management.auto_upgrade is true
+		}
+	}
+}
+
+main = rule {
+	node_auto_upgrade_is_enabled
+}

--- a/gcp/kubernetes/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes/test/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes/failure.json
+++ b/gcp/kubernetes/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes/test/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes/test/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes/success.json
+++ b/gcp/kubernetes/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes/test/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    null,
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": null,
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "ubuntu_containerd",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": false,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes/testdata/mock-tfplan-success.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    "logging.googleapis.com/kubernetes",
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": "monitoring.googleapis.com/kubernetes",
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image.sentinel
@@ -1,0 +1,42 @@
+import "tfplan/v2" as tfplan
+import "strings"
+
+supportedImageTypes = [
+	"cos",
+	"cos_containerd",
+]
+
+allContainerClusters = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_cluster" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+allNodePools = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.type is "google_container_node_pool" and
+		resource_changes.mode is "managed" and
+		resource_changes.change.actions is ["create"]
+}
+
+print("CIS 7.9: Ensure Container-Optimized OS (cos) is used for Kubernetes Engine Clusters Node image")
+
+cluster_node_config_image_type_is_cos = rule {
+	all allContainerClusters as _, cluster {
+		all cluster.change.after.node_config as _, node_config {
+			strings.to_lower(node_config.image_type) in supportedImageTypes
+		}
+	}
+}
+
+pool_node_config_image_type_is_cos = rule {
+	all allNodePools as _, pool {
+		all pool.change.after.node_config as _, node_config {
+			strings.to_lower(node_config.image_type) in supportedImageTypes
+		}
+	}
+}
+
+main = rule {
+	cluster_node_config_image_type_is_cos and
+	pool_node_config_image_type_is_cos
+}

--- a/gcp/kubernetes/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image/test/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image/failure.json
+++ b/gcp/kubernetes/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image/test/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image/failure.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-failure.sentinel"
+    },
+    "test": {
+        "main": false
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image/test/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image/success.json
+++ b/gcp/kubernetes/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image/test/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image/success.json
@@ -1,0 +1,8 @@
+{
+    "mock": {
+        "tfplan/v2": "../../testdata/mock-tfplan-success.sentinel"
+    },
+    "test": {
+        "main": true
+    }
+}

--- a/gcp/kubernetes/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image/testdata/mock-tfplan-failure.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    null,
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": null,
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "ubuntu_containerd",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "ubuntu_containerd",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}

--- a/gcp/kubernetes/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image/testdata/mock-tfplan-success.sentinel
+++ b/gcp/kubernetes/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,188 @@
+resource_changes = {
+	"google_container_cluster.this": {
+		"address": "google_container_cluster.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"addons_config": [
+					{
+						"network_policy_config": [
+							{
+								"disabled": false,
+							},
+						],
+					},
+				],
+				"description":                 null,
+				"enable_binary_authorization": false,
+				"enable_intranode_visibility": false,
+				"enable_kubernetes_alpha":     false,
+				"enable_legacy_abac":          false,
+				"enable_shielded_nodes":       false,
+				"enable_tpu":                  false,
+				"initial_node_count":          1,
+				"ip_allocation_policy": [
+					{
+						"cluster_secondary_range_name":  "pods",
+						"services_secondary_range_name": "services",
+					},
+				],
+				"location":           "australia-southeast1",
+				"logging_service":    "logging.googleapis.com/kubernetes",
+				"maintenance_policy": [],
+				"master_auth": [
+					{
+						"client_certificate_config": [
+							{
+								"issue_client_certificate": true,
+							},
+						],
+						"password": "",
+						"username": "",
+					},
+				],
+				"master_authorized_networks_config": [
+					{
+						"cidr_blocks": [
+							{
+								"cidr_block":   "10.0.0.0/8",
+								"display_name": "10x",
+							},
+							{
+								"cidr_block":   "172.16.0.0/12",
+								"display_name": "172x",
+							},
+							{
+								"cidr_block":   "192.168.0.0/16",
+								"display_name": "192x",
+							},
+						],
+					},
+				],
+				"min_master_version": null,
+				"monitoring_service": "monitoring.googleapis.com/kubernetes",
+				"name":               "this-cluster",
+				"network":            "default",
+				"network_policy": [
+					{
+						"enabled":  true,
+						"provider": null,
+					},
+				],
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"pod_security_policy_config": [
+					{
+						"enabled": true,
+					},
+				],
+				"private_cluster_config": [
+					{
+						"enable_private_endpoint": null,
+						"enable_private_nodes":    true,
+						"master_ipv4_cidr_block":  "172.16.0.32/28",
+					},
+				],
+				"remove_default_node_pool":     true,
+				"resource_labels":              null,
+				"resource_usage_export_config": [],
+				"timeouts": {
+					"create": "30m",
+					"delete": null,
+					"update": "40m",
+				},
+				"vertical_pod_autoscaling": [],
+				"workload_identity_config": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_cluster",
+	},
+	"google_container_node_pool.this": {
+		"address": "google_container_node_pool.this",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"autoscaling": [],
+				"cluster":     "this-cluster",
+				"location":    "australia-southeast1",
+				"management": [
+					{
+						"auto_repair":  true,
+						"auto_upgrade": true,
+					},
+				],
+				"name": "this-pool",
+				"node_config": [
+					{
+						"boot_disk_kms_key": null,
+						"image_type":        "COS",
+						"labels": {
+							"foo": "bar",
+						},
+						"machine_type": "n1-standard-1",
+						"metadata": {
+							"disable-legacy-endpoints": "true",
+						},
+						"min_cpu_platform": null,
+						"oauth_scopes": [
+							"https://www.googleapis.com/auth/devstorage.read_only",
+							"https://www.googleapis.com/auth/logging.write",
+							"https://www.googleapis.com/auth/monitoring",
+						],
+						"preemptible":     true,
+						"sandbox_config":  [],
+						"service_account": "node-service-account-field",
+						"tags":            null,
+						"workload_metadata_config": [],
+					},
+				],
+				"node_count":       1,
+				"timeouts":         null,
+				"upgrade_settings": [],
+			},
+			"after_unknown": {},
+			"before":        null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "this",
+		"provider_name":  "google-beta",
+		"type":           "google_container_node_pool",
+	},
+}


### PR DESCRIPTION
This PR provides Sentinel policies that follow the security recommendations that are provided in the CIS Google Cloud Computing Platform Foundations Benchmark v.1.0.0, namely:

## CIS 7.1: Ensure Stackdriver Logging is set to Enabled on Kubernetes Engine Clusters

### Description
Stackdriver Logging is part of the Stackdriver suite of products in Google Cloud Platform. It includes storage for logs, a user interface called the Logs Viewer, and an API to manage logs programmatically. Stackdriver Logging lets you have Kubernetes Engine automatically collect, process, and store your container and system logs in a dedicated, persistent datastore. Container logs are collected from your containers. System logs are collected from the cluster's components, such as docker and kubelet. Events are logs about activity in the cluster, such as the scheduling of Pods.

### Configuration

```hcl
policy "gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters/gcp-cis-7.1-kubernetes-ensure-stackdriver-logging-is-set-to-enabled-on-kubernetes-engine-clusters.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 7.2: Ensure Stackdriver Monitoring is set to Enabled on Kubernetes Engine Clusters

### Description
Stackdriver Monitoring to monitor signals and build operations in your Kubernetes Engine clusters. Stackdriver Monitoring can access metrics about CPU utilization, some disk traffic metrics, network traffic, and uptime information. Stackdriver Monitoring uses the Monitoring agent to access additional system resources and application services in virtual machine instances.

### Configuration
```hcl
policy "gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters/gcp-cis-7.2-kubernetes-ensure-stackdriver-monitoring-is-set-to-enabled-on-kubernetes-engine-clusters.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 7.3: Ensure Legacy Authorization is set to Disabled on Kubernetes Engine Clusters

### Description
In Kubernetes, authorizers interact by granting a permission if any authorizer grants the permission. The legacy authorizer in Kubernetes Engine grants broad, statically defined permissions. To ensure that RBAC limits permissions correctly, you must disable the legacy authorizer. RBAC has significant security advantages, can help you ensure that users only have access to cluster resources within their own namespace and is now stable in Kubernetes.

### Configuration
```hcl
policy "gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters/gcp-cis-7.3-kubernetes-ensure-legacy-authorization-is-set-to-disabled-on-kubernetes-engine-clusters.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 7.4: Ensure Master authorized networks is set to Enabled on Kubernetes Engine Clusters

### Description
Authorized networks are a way of specifying a restricted range of IP addresses that are permitted to access your container cluster's Kubernetes master endpoint. Kubernetes Engine uses both Transport Layer Security (TLS) and authentication to provide secure access to your container cluster's Kubernetes master endpoint from the public internet. This provides you the flexibility to administer your cluster from anywhere; however, you might want to further restrict access to a set of IP addresses that you control. You can set this restriction by specifying an authorized network.

### Configuration
```hcl
policy "gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters/gcp-cis-7.4-kubernetes-ensure-master-authorized-networks-is-set-to-enabled-on-kubernetes-engine-clusters.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 7.5: Ensure Kubernetes Clusters are configured with Labels

### Description
A cluster label is a key-value pair that helps you organize your Google Cloud Platform resources, such as clusters. You can attach a label to each resource, then filter the resources based on their labels. Information about labels is forwarded to the billing system, so you can break down your billing charges by the label.

### Configuration
```hcl
policy "gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels/gcp-cis-7.5-kubernetes-ensure-kubernetes-clusters-are-configured-with-labels.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 7.7: Ensure Automatic node repair is enabled for Kubernetes Clusters

### Description
Kubernetes Engine's node auto-repair feature helps you keep the nodes in your cluster in a healthy, running state. When enabled, Kubernetes Engine makes periodic checks on the health state of each node in your cluster. If a node fails consecutive health checks over an extended time period, Kubernetes Engine initiates a repair process for that node. If you disable node auto-repair at any time during the repair process, the in-progress repairs are not cancelled and still complete for any node currently under repair.

### Configuration
```hcl
policy "gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters/gcp-cis-7.7-kubernetes-ensure-automatic-node-repair-is-enabled-for-kubernetes-clusters.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 7.8: Ensure Automatic node upgrades is enabled on Kubernetes Engine Clusters nodes

### Description
Node auto-upgrades help you keep the nodes in your cluster or node pool up to date with the latest stable version of Kubernetes. Auto-Upgrades use the same update mechanism as manual node upgrades.

### Configuration
```hcl
policy "gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes/gcp-cis-7.8-kubernetes-ensure-automatic-node-upgrades-is-enabled-on-kubernetes-engine-clusters-nodes.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 7.9: Ensure Container-Optimized OS (cos) is used for Kubernetes Engine Clusters Node image

### Description
Container-Optimized OS is an operating system image for your Compute Engine VMs that is optimized for running Docker containers. With Container-Optimized OS, you can bring up your Docker containers on Google Cloud Platform quickly, efficiently, and securely.

### Configuration
```hcl
policy "gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image/gcp-cis-7.9-kubernetes-ensure-container-optimized-osis-used-for-kubernetes-engine-clusters-node-image.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 7.10: Ensure Basic Authentication is disabled on Kubernetes Engine Clusters

### Description
Basic authentication allows a user to authenticate to the cluster with a username and password and it is stored in plain text without any encryption. Disabling Basic authentication will prevent attacks like brute force. Its recommended to use either client certificate or IAM for authentication.

### Configuration
```hcl
policy "gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 7.11: Ensure Network policy is enabled on Kubernetes Engine Clusters

### Description
A network policy is a specification of how groups of pods are allowed to communicate with each other and other network endpoints. NetworkPolicy resources use labels to select pods and define rules which specify what traffic is allowed to the selected pods. The Kubernetes Network Policy API allows the cluster administrator to specify what pods are allowed to communicate with each other.

### Configuration
```hcl
policy "gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters/gcp-cis-7.11-kubernetes-ensure-network-policy-is-enabled-on-kubernetes-engine-clusters.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 7.12: Ensure Kubernetes Cluster is created with Client Certificate enabled

### Description
If you disable client certificate generation to create a cluster without a client certificate. You will still be able to authenticate to the cluster with basic auth or IAM. But basic auth allows a user to authenticate to the cluster with a username and password which are stored in plain text without any encryption and might lead brute force attacks.

### Configuration
```hcl
policy "gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled/gcp-cis-7.12-kubernetes-ensure-kubernetes-cluster-is-created-with-client-certificate-enabled.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 7.13: Ensure Kubernetes Cluster is created with Alias IP ranges enabled

### Description
Google Cloud Platform Alias IP Ranges lets you assign ranges of internal IP addresses as aliases to a virtual machine's network interfaces. This is useful if you have multiple services running on a VM and you want to assign each service a different IP address.

### Configuration
```hcl
policy "gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled/gcp-cis-7.13-kubernetes-ensure-kubernetes-cluster-is-created-with-alias-ip-ranges-enabled.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 7.14: Ensure PodSecurityPolicy controller is enabled on the Kubernetes Engine Clusters

### Description
A Pod Security Policy is a cluster-level resource that controls security sensitive aspects of the pod specification. The PodSecurityPolicy objects define a set of conditions that a pod must run with in order to be accepted into the system, as well as defaults for the related fields.

### Configuration
```hcl
policy "gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters/gcp-cis-7.14-kubernetes-ensure-podsecuritypolicy-controller-is-enabled-on-the-kubernetes-engine-clusters.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 7.15: Ensure Kubernetes Cluster is created with Private cluster enabled

### Description
A private cluster is a cluster that makes your master inaccessible from the public internet. In a private cluster, nodes do not have public IP addresses, so your workloads run in an environment that is isolated from the internet. Nodes have addressed only in the private RFC 1918 address space. Nodes and masters communicate with each other privately using VPC peering.

### Configuration
```hcl
policy "gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled/gcp-cis-7.15-kubernetes-ensure-kubernetes-cluster-is-created-with-private-cluster-enabled.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 7.17: Ensure default Service account is not used for Project access in Kubernetes Clusters

### Description
A service account is an identity that an instance or an application can use to run API requests on your behalf. This identity is used to identify applications running on your virtual machine instances to other Google Cloud Platform services. By default, Kubernetes Engine nodes are given the Compute Engine default service account. This account has broad access by default, making it useful to a wide variety of applications, but it has more permissions than are required to run your Kubernetes Engine cluster.

### Configuration
```hcl
policy "gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters/gcp-cis-7.17-kubernetes-ensure-default-service-account-is-not-used-for-project-access-in-kubernetes-clusters.sentinel"
    enforcement_level = "advisory"
}
```

## CIS 7.18: Ensure Kubernetes Clusters created with limited service account Access scopes for Project access

### Description
Access scopes are the legacy method of specifying permissions for your instance. Before the existence of IAM roles, access scopes were the only mechanism for granting permissions to service accounts. By default, your node service account has access scopes.

### Configuration
```hcl
policy "gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access" {
    source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/gcp/kubernetes/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access/gcp-cis-7.18-kubernetes-ensure-kubernetes-clusters-created-with-limited-service-account-access-scopes-for-project-access.sentinel"
    enforcement_level = "advisory"
}
```
