### PR TITLE
Update the detection logic in the basic_authentication_is_disabled rule

### DIFF
--- a/cis/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters.sentinel
+++ b/cis/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters.sentinel
@@ -9,22 +9,24 @@ allContainerClusters = filter tfplan.resource_changes as _, resource_changes {
 
 print("CIS 7.10: Ensure Basic Authentication is disabled on Kubernetes Engine Clusters")
 
-deny_undefined_master_auth = rule {
+master_auth_is_defined = rule {
 	all allContainerClusters as _, cluster {
 		keys(cluster.change.after) contains "master_auth"
 	}
 }
 
-basic_authentication_is_disabled = rule when deny_undefined_master_auth is true {
+basic_authentication_is_disabled = rule when master_auth_is_defined is true {
 	all allContainerClusters as _, cluster {
 		all cluster.change.after.master_auth as _, master_auth {
-			keys(master_auth) not contains "username" and
-				keys(master_auth) not contains "password"
+			keys(master_auth) contains "username" and
+				length(master_auth.username) == 0 and
+				keys(master_auth) contains "password" and
+				length(master_auth.password) == 0
 		}
 	}
 }
 
 main = rule {
-	deny_undefined_master_auth and
+	master_auth_is_defined and
 	basic_authentication_is_disabled
 }

--- a/cis/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-failure.sentinel
+++ b/cis/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-failure.sentinel
@@ -39,8 +39,8 @@ resource_changes = {
 								"issue_client_certificate": true,
 							},
 						],
-						"password": "",
-						"username": "",
+						"password": "somevalue",
+						"username": "somevalue",
 					},
 				],
 				"master_authorized_networks_config": [

--- a/cis/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-success.sentinel
+++ b/cis/gcp/kubernetes/gcp-cis-7.10-kubernetes-ensure-basic-authentication-is-disabled-on-kubernetes-engine-clusters/testdata/mock-tfplan-success.sentinel
@@ -39,6 +39,8 @@ resource_changes = {
 								"issue_client_certificate": true,
 							},
 						],
+						"password": "",
+						"username": "",
 					},
 				],
 				"master_authorized_networks_config": [


### PR DESCRIPTION
This PR updates the policy configuration for GCP CIS 7.10. Prior to this update, the policy was checking for the existence of a `username` and `password` key for the master_auth stanza. 

We have extended the logic to check the values for each key, as the value needs to be an empty string, in order for basic authentication to be disabled. 

This requirement is covered in more detail in the
[google_container_cluster](https://www.terraform.io/docs/providers/google/r/container_cluster.html) documentation.