### PR TITLE
compute policies fail when metadata is not configured

### DIFF
--- a/cis/gcp/compute/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances.sentinel
+++ b/cis/gcp/compute/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances/gcp-cis-4.2-compute-block-project-wide-ssh-keys-enabled-for-vm-instances.sentinel
@@ -19,7 +19,7 @@ print("CIS 4.2: Ensure 'Block Project-wide SSH keys' are enabled for VM instance
 
 deny_undefined_compute_instance_metadata = rule {
 	all allComputeInstances as _, instances {
-		keys(instances.change.after) contains "metadata"
+		instances.change.after.metadata is not null
 	}
 }
 

--- a/cis/gcp/compute/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project.sentinel
+++ b/cis/gcp/compute/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project/gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project.sentinel
@@ -19,7 +19,7 @@ print("CIS 4.3: Ensure oslogin is enabled for a project")
 
 deny_undefined_compute_instance_metadata = rule {
 	all allComputeInstances as _, instances {
-		keys(instances.change.after) contains "metadata"
+		instances.change.after.metadata is not null
 	}
 }
 

--- a/cis/gcp/compute/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance.sentinel
+++ b/cis/gcp/compute/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance/gcp-cis-4.4-compute-enable-connecting-to-serial-ports-is-not-enabled-for-vm-instance.sentinel
@@ -19,7 +19,7 @@ print("CIS 4.4: Ensure 'Enable connecting to serial ports' is not enabled for VM
 
 deny_undefined_compute_instance_metadata = rule {
 	all allComputeInstances as _, instances {
-		keys(instances.change.after) contains "metadata"
+		instances.change.after.metadata is not null
 	}
 }
 


### PR DESCRIPTION
When metadata is not present in the terraform resource, the tfplan has the metadata value as null instead of the key not being present at all. 
This results in the below failure failures : 
Error: gcp-cis-4.3-compute-ensure-oslogin-is-enabled-for-a-project.sentinel:28:3: keys first argument can only be called with maps, got "null"
