### PR TITLE
Update github action to use the official Sentinel docker image

### DIFF
--- a/.github/workflows/sentinel.yml
+++ b/.github/workflows/sentinel.yml
@@ -10,12 +10,10 @@ jobs:
     container:
       image: hashicorp/sentinel
     steps:
-      - name: Git Version
-        run: git --version
       - name: Checkout
         uses: actions/checkout@v2
       - name: Sentinel Format
-        run: fmt -check=true $(find . -name "*.sentinel")
+        run: sentinel fmt -check=true $(find . -name "*.sentinel")
   sentinel-test:
     needs: sentinel-format
     runs-on: ubuntu-latest
@@ -25,4 +23,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Sentinel Test
-        run: test $(find . -name "*.sentinel" ! -path "*/testdata/*")
+        run: sentinel test $(find . -name "*.sentinel" ! -path "*/testdata/*")

--- a/.github/workflows/sentinel.yml
+++ b/.github/workflows/sentinel.yml
@@ -10,6 +10,8 @@ jobs:
     container:
       image: hashicorp/sentinel
     steps:
+      - name: Git Version
+        run: git --version
       - name: Checkout
         uses: actions/checkout@v2
       - name: Sentinel Format

--- a/.github/workflows/sentinel.yml
+++ b/.github/workflows/sentinel.yml
@@ -8,19 +8,19 @@ jobs:
   sentinel-format:
     runs-on: ubuntu-latest
     container:
-      image: thrashr888/sentinel-simulator
+      image: hashicorp/sentinel
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Sentinel Format
-        run: sentinel fmt -check=true $(find . -name "*.sentinel")
+        run: fmt -check=true $(find . -name "*.sentinel")
   sentinel-test:
     needs: sentinel-format
     runs-on: ubuntu-latest
     container:
-      image: thrashr888/sentinel-simulator
+      image: hashicorp/sentinel
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Sentinel Test
-        run: sentinel test $(find . -name "*.sentinel" ! -path "*/testdata/*")
+        run: test $(find . -name "*.sentinel" ! -path "*/testdata/*")


### PR DESCRIPTION
This PR updates the GitHub Action configuration so that it will use the HashiCorp official docker image for the Sentinel CLI