### PR TITLE
feature: storage account network rules

### DIFF
--- a/cis/azure/storage/azure-cis-3.7-storage-default-network-access-rule-set-to-deny/azure-cis-3.7-storage-default-network-access-rule-set-to-deny.sentinel
+++ b/cis/azure/storage/azure-cis-3.7-storage-default-network-access-rule-set-to-deny/azure-cis-3.7-storage-default-network-access-rule-set-to-deny.sentinel
@@ -7,15 +7,22 @@ allStorageAccounts = filter tfplan.resource_changes as _, resource_changes {
 			resource_changes.change.actions is ["update"])
 }
 
+allStorageAccountNetworkRules = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.mode is "managed" and
+		resource_changes.type is "azurerm_storage_account_network_rules" and
+		(resource_changes.change.actions contains "create" or
+			resource_changes.change.actions is ["update"])
+}
+
 print("CIS 3.7: Ensure default network access rule for Storage Accounts is set to deny")
 
-deny_undefined_network_rules = rule {
+storage_account_contains_network_rules = rule {
 	all allStorageAccounts as _, accounts {
 		keys(accounts.change.after) contains "network_rules"
 	}
 }
 
-network_rules_default_action_is_deny = rule when deny_undefined_network_rules is true {
+storage_account_network_rules_default_action_is_deny = rule when storage_account_contains_network_rules is true {
 	all allStorageAccounts as _, accounts {
 		all accounts.change.after.network_rules as network_rules {
 			network_rules.default_action is "Deny"
@@ -23,7 +30,66 @@ network_rules_default_action_is_deny = rule when deny_undefined_network_rules is
 	}
 }
 
+storage_account_has_built_in_network_rule = func(allStorageAccounts, allStorageAccountNetworkRules) {
+	mapStandaloneStorageAccountNetworkRules = {}
+	for allStorageAccounts as _, accounts {
+		if keys(accounts.change.after) contains "network_rules" {
+			for allStorageAccountNetworkRules as nr {
+				networkRuleStorageAccountName = allStorageAccountNetworkRules[nr]["change"]["after"]["storage_account_name"]
+				if networkRuleStorageAccountName is accounts.name {
+					mapStandaloneStorageAccountNetworkRules[networkRuleStorageAccountName] = nr
+				}
+			}
+		}
+	}
+	return length(mapStandaloneStorageAccountNetworkRules) == 0
+}
+
+storage_account_has_standalone_storage_account_network_rule = func(allStorageAccounts, allStorageAccountNetworkRules) {
+	mapStandaloneStorageAccountNetworkRules = {}
+	for allStorageAccounts as _, accounts {
+		if keys(accounts.change.after) not contains "network_rules" {
+			for allStorageAccountNetworkRules as nr {
+				networkRuleStorageAccountName = allStorageAccountNetworkRules[nr]["change"]["after"]["storage_account_name"]
+				if networkRuleStorageAccountName is accounts.name {
+					mapStandaloneStorageAccountNetworkRules[networkRuleStorageAccountName] = nr
+				}
+			}
+		}
+	}
+	return length(mapStandaloneStorageAccountNetworkRules) == 1
+}
+
+# Check if standalone Storage Account Network Rules block(s) was defined.
+#
+# Network Rules can be defined either directly on the
+# azurerm_storage_account resource,
+# or using the
+# azurerm_storage_account_network_rules resource
+# - but the two cannot be used together.
+# Spurious changes will occur if both are used against the same Storage Account.
+#
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account_network_rules
+
+standalone_network_rules_contains_default_action = rule {
+	all allStorageAccountNetworkRules as _, network_rules {
+		keys(network_rules.change.after) contains "default_action"
+	}
+}
+
+standalone_network_rules_default_action_is_deny = rule when standalone_network_rules_contains_default_action is true {
+	all allStorageAccountNetworkRules as _, network_rules {
+		network_rules.change.after.default_action is "Deny"
+	}
+}
+
 main = rule {
-	deny_undefined_network_rules and
-	network_rules_default_action_is_deny
+	(storage_account_has_built_in_network_rule(
+		allStorageAccounts,allStorageAccountNetworkRules) == true and
+	storage_account_contains_network_rules and
+	storage_account_network_rules_default_action_is_deny) or
+	(storage_account_has_standalone_storage_account_network_rule(
+		allStorageAccounts,allStorageAccountNetworkRules) == true and
+	standalone_network_rules_contains_default_action and
+	standalone_network_rules_default_action_is_deny)
 }

--- a/cis/azure/storage/azure-cis-3.7-storage-default-network-access-rule-set-to-deny/azure-cis-3.7-storage-default-network-access-rule-set-to-deny.sentinel
+++ b/cis/azure/storage/azure-cis-3.7-storage-default-network-access-rule-set-to-deny/azure-cis-3.7-storage-default-network-access-rule-set-to-deny.sentinel
@@ -16,13 +16,13 @@ allStorageAccountNetworkRules = filter tfplan.resource_changes as _, resource_ch
 
 print("CIS 3.7: Ensure default network access rule for Storage Accounts is set to deny")
 
-storage_account_contains_built_in_network_rules = rule {
+storage_account_has_built_in_network_rules = rule {
 	all allStorageAccounts as _, accounts {
 		keys(accounts.change.after) contains "network_rules"
 	}
 }
 
-storage_account_built_in_network_rules_default_action_is_deny = rule when storage_account_contains_built_in_network_rules is true {
+storage_account_built_in_network_rules_default_action_is_deny = rule when storage_account_has_built_in_network_rules is true {
 	all allStorageAccounts as _, accounts {
 		all accounts.change.after.network_rules as network_rules {
 			network_rules.default_action is "Deny"
@@ -71,13 +71,13 @@ storage_account_has_standalone_storage_account_network_rule = func(allStorageAcc
 #
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account_network_rules
 
-standalone_network_rules_contains_default_action = rule {
+standalone_network_rules_has_default_action = rule {
 	all allStorageAccountNetworkRules as _, network_rules {
 		keys(network_rules.change.after) contains "default_action"
 	}
 }
 
-standalone_network_rules_default_action_is_deny = rule when standalone_network_rules_contains_default_action is true {
+standalone_network_rules_default_action_is_deny = rule when standalone_network_rules_has_default_action is true {
 	all allStorageAccountNetworkRules as _, network_rules {
 		network_rules.change.after.default_action is "Deny"
 	}
@@ -87,11 +87,11 @@ main = rule {
 	(storage_account_has_built_in_network_rule(
 		allStorageAccounts, allStorageAccountNetworkRules) ==
 		true and
-		storage_account_contains_built_in_network_rules and
+		storage_account_has_built_in_network_rules and
 		storage_account_built_in_network_rules_default_action_is_deny) or
 	(storage_account_has_standalone_storage_account_network_rule(
 		allStorageAccounts, allStorageAccountNetworkRules) ==
 		true and
-		standalone_network_rules_contains_default_action and
+		standalone_network_rules_has_default_action and
 		standalone_network_rules_default_action_is_deny)
 }

--- a/cis/azure/storage/azure-cis-3.7-storage-default-network-access-rule-set-to-deny/azure-cis-3.7-storage-default-network-access-rule-set-to-deny.sentinel
+++ b/cis/azure/storage/azure-cis-3.7-storage-default-network-access-rule-set-to-deny/azure-cis-3.7-storage-default-network-access-rule-set-to-deny.sentinel
@@ -85,11 +85,13 @@ standalone_network_rules_default_action_is_deny = rule when standalone_network_r
 
 main = rule {
 	(storage_account_has_built_in_network_rule(
-		allStorageAccounts,allStorageAccountNetworkRules) == true and
-	storage_account_contains_network_rules and
-	storage_account_network_rules_default_action_is_deny) or
+		allStorageAccounts, allStorageAccountNetworkRules) ==
+		true and
+		storage_account_contains_network_rules and
+		storage_account_network_rules_default_action_is_deny) or
 	(storage_account_has_standalone_storage_account_network_rule(
-		allStorageAccounts,allStorageAccountNetworkRules) == true and
-	standalone_network_rules_contains_default_action and
-	standalone_network_rules_default_action_is_deny)
+		allStorageAccounts, allStorageAccountNetworkRules) ==
+		true and
+		standalone_network_rules_contains_default_action and
+		standalone_network_rules_default_action_is_deny)
 }

--- a/cis/azure/storage/azure-cis-3.7-storage-default-network-access-rule-set-to-deny/azure-cis-3.7-storage-default-network-access-rule-set-to-deny.sentinel
+++ b/cis/azure/storage/azure-cis-3.7-storage-default-network-access-rule-set-to-deny/azure-cis-3.7-storage-default-network-access-rule-set-to-deny.sentinel
@@ -16,13 +16,13 @@ allStorageAccountNetworkRules = filter tfplan.resource_changes as _, resource_ch
 
 print("CIS 3.7: Ensure default network access rule for Storage Accounts is set to deny")
 
-storage_account_contains_network_rules = rule {
+storage_account_contains_built_in_network_rules = rule {
 	all allStorageAccounts as _, accounts {
 		keys(accounts.change.after) contains "network_rules"
 	}
 }
 
-storage_account_network_rules_default_action_is_deny = rule when storage_account_contains_network_rules is true {
+storage_account_built_in_network_rules_default_action_is_deny = rule when storage_account_contains_built_in_network_rules is true {
 	all allStorageAccounts as _, accounts {
 		all accounts.change.after.network_rules as network_rules {
 			network_rules.default_action is "Deny"
@@ -87,8 +87,8 @@ main = rule {
 	(storage_account_has_built_in_network_rule(
 		allStorageAccounts, allStorageAccountNetworkRules) ==
 		true and
-		storage_account_contains_network_rules and
-		storage_account_network_rules_default_action_is_deny) or
+		storage_account_contains_built_in_network_rules and
+		storage_account_built_in_network_rules_default_action_is_deny) or
 	(storage_account_has_standalone_storage_account_network_rule(
 		allStorageAccounts, allStorageAccountNetworkRules) ==
 		true and

--- a/cis/azure/storage/azure-cis-3.7-storage-default-network-access-rule-set-to-deny/testdata/mock-tfplan-failure.sentinel
+++ b/cis/azure/storage/azure-cis-3.7-storage-default-network-access-rule-set-to-deny/testdata/mock-tfplan-failure.sentinel
@@ -74,4 +74,109 @@ resource_changes = {
 		"provider_name":  "azurerm",
 		"type":           "azurerm_storage_account",
 	},
+	"azurerm_storage_account.account": {
+		"address": "azurerm_storage_account.account",
+		"change": {
+			"actions": [
+				"delete",
+				"create",
+			],
+			"after": {
+				"account_kind":             "StorageV2",
+				"account_replication_type": "LRS",
+				"account_tier":             "Standard",
+				"allow_blob_public_access": false,
+				"blob_properties": [
+					{
+						"cors_rule": [],
+						"delete_retention_policy": [
+							{
+								"days": 365,
+							},
+						],
+					},
+				],
+				"custom_domain":             [],
+				"enable_https_traffic_only": true,
+				"is_hns_enabled":            false,
+				"location":                  "westeurope",
+				"min_tls_version":           "TLS1_0",
+				"name":                      "account",
+				"queue_properties": [
+					{
+						"cors_rule": [],
+						"hour_metrics": [
+							{
+								"enabled":               true,
+								"include_apis":          true,
+								"retention_policy_days": 10,
+								"version":               "1.0",
+							},
+						],
+						"logging": [
+							{
+								"delete":                true,
+								"read":                  true,
+								"retention_policy_days": 10,
+								"version":               "1.0",
+								"write":                 true,
+							},
+						],
+						"minute_metrics": [
+							{
+								"enabled":               true,
+								"include_apis":          true,
+								"retention_policy_days": 10,
+								"version":               "1.0",
+							},
+						],
+					},
+				],
+				"resource_group_name": "sentinel-foundational-azure",
+				"static_website":      [],
+				"tags":                null,
+				"timeouts":            null,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "account",
+		"provider_name":  "azurerm",
+		"type":           "azurerm_storage_account",
+	},
+	"azurerm_storage_account_network_rules.rules": {
+		"address": "azurerm_storage_account_network_rules.rules",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"bypass": [
+					"AzureServices",
+				],
+				"default_action":       "Allow",
+				"resource_group_name":  "sentinel-foundational-azure",
+				"storage_account_name": "account",
+				"timeouts":             null,
+			},
+			"after_unknown": {
+				"bypass": [
+					false,
+				],
+				"id":                         true,
+				"ip_rules":                   true,
+				"virtual_network_subnet_ids": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "rules",
+		"provider_name":  "azurerm",
+		"type":           "azurerm_storage_account_network_rules",
+	},
 }

--- a/cis/azure/storage/azure-cis-3.7-storage-default-network-access-rule-set-to-deny/testdata/mock-tfplan-success.sentinel
+++ b/cis/azure/storage/azure-cis-3.7-storage-default-network-access-rule-set-to-deny/testdata/mock-tfplan-success.sentinel
@@ -74,4 +74,109 @@ resource_changes = {
 		"provider_name":  "azurerm",
 		"type":           "azurerm_storage_account",
 	},
+	"azurerm_storage_account.account": {
+		"address": "azurerm_storage_account.account",
+		"change": {
+			"actions": [
+				"delete",
+				"create",
+			],
+			"after": {
+				"account_kind":             "StorageV2",
+				"account_replication_type": "LRS",
+				"account_tier":             "Standard",
+				"allow_blob_public_access": false,
+				"blob_properties": [
+					{
+						"cors_rule": [],
+						"delete_retention_policy": [
+							{
+								"days": 365,
+							},
+						],
+					},
+				],
+				"custom_domain":             [],
+				"enable_https_traffic_only": true,
+				"is_hns_enabled":            false,
+				"location":                  "westeurope",
+				"min_tls_version":           "TLS1_0",
+				"name":                      "account",
+				"queue_properties": [
+					{
+						"cors_rule": [],
+						"hour_metrics": [
+							{
+								"enabled":               true,
+								"include_apis":          true,
+								"retention_policy_days": 10,
+								"version":               "1.0",
+							},
+						],
+						"logging": [
+							{
+								"delete":                true,
+								"read":                  true,
+								"retention_policy_days": 10,
+								"version":               "1.0",
+								"write":                 true,
+							},
+						],
+						"minute_metrics": [
+							{
+								"enabled":               true,
+								"include_apis":          true,
+								"retention_policy_days": 10,
+								"version":               "1.0",
+							},
+						],
+					},
+				],
+				"resource_group_name": "sentinel-foundational-azure",
+				"static_website":      [],
+				"tags":                null,
+				"timeouts":            null,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "account",
+		"provider_name":  "azurerm",
+		"type":           "azurerm_storage_account",
+	},
+	"azurerm_storage_account_network_rules.rules": {
+		"address": "azurerm_storage_account_network_rules.rules",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"bypass": [
+					"AzureServices",
+				],
+				"default_action":       "Deny",
+				"resource_group_name":  "sentinel-foundational-azure",
+				"storage_account_name": "account",
+				"timeouts":             null,
+			},
+			"after_unknown": {
+				"bypass": [
+					false,
+				],
+				"id":                         true,
+				"ip_rules":                   true,
+				"virtual_network_subnet_ids": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "rules",
+		"provider_name":  "azurerm",
+		"type":           "azurerm_storage_account_network_rules",
+	},
 }

--- a/cis/azure/storage/azure-cis-3.8-storage-trusted-microsoft-services-is-enabled/azure-cis-3.8-storage-trusted-microsoft-services-is-enabled.sentinel
+++ b/cis/azure/storage/azure-cis-3.8-storage-trusted-microsoft-services-is-enabled/azure-cis-3.8-storage-trusted-microsoft-services-is-enabled.sentinel
@@ -1,4 +1,5 @@
 import "tfplan/v2" as tfplan
+import "types"
 
 allStorageAccounts = filter tfplan.resource_changes as _, resource_changes {
 	resource_changes.mode is "managed" and
@@ -7,15 +8,22 @@ allStorageAccounts = filter tfplan.resource_changes as _, resource_changes {
 			resource_changes.change.actions is ["update"])
 }
 
+allStorageAccountNetworkRules = filter tfplan.resource_changes as _, resource_changes {
+	resource_changes.mode is "managed" and
+		resource_changes.type is "azurerm_storage_account_network_rules" and
+		(resource_changes.change.actions contains "create" or
+			resource_changes.change.actions is ["update"])
+}
+
 print("CIS 3.8: Ensure 'Trusted Microsoft Services' is enabled for Storage Account access")
 
-deny_undefined_network_rules = rule {
+storage_account_has_built_in_network_rules = rule {
 	all allStorageAccounts as _, accounts {
 		keys(accounts.change.after) contains "network_rules"
 	}
 }
 
-deny_undefined_network_rules_bypass = rule when deny_undefined_network_rules is true {
+storage_account_built_in_network_rules_have_bypass = rule when storage_account_has_built_in_network_rules is true {
 	all allStorageAccounts as _, accounts {
 		all accounts.change.after.network_rules as network_rules {
 			keys(network_rules) contains "bypass"
@@ -23,7 +31,7 @@ deny_undefined_network_rules_bypass = rule when deny_undefined_network_rules is 
 	}
 }
 
-network_rules_default_action_is_deny = rule when deny_undefined_network_rules_bypass is true {
+storage_account_built_in_network_rules_bypass_is_azure_services = rule when storage_account_built_in_network_rules_have_bypass is true {
 	all allStorageAccounts as _, accounts {
 		all accounts.change.after.network_rules as network_rules {
 			all network_rules.bypass as bypass {
@@ -33,8 +41,85 @@ network_rules_default_action_is_deny = rule when deny_undefined_network_rules_by
 	}
 }
 
+storage_account_has_built_in_network_rule = func(allStorageAccounts, allStorageAccountNetworkRules) {
+	mapStandaloneStorageAccountNetworkRules = {}
+	for allStorageAccounts as _, accounts {
+		if keys(accounts.change.after) contains "network_rules" {
+			for allStorageAccountNetworkRules as nr {
+				networkRuleStorageAccountName = allStorageAccountNetworkRules[nr]["change"]["after"]["storage_account_name"]
+				if networkRuleStorageAccountName is accounts.name {
+					mapStandaloneStorageAccountNetworkRules[networkRuleStorageAccountName] = nr
+				}
+			}
+		}
+	}
+	return length(mapStandaloneStorageAccountNetworkRules) == 0
+}
+
+storage_account_has_standalone_storage_account_network_rule = func(allStorageAccounts, allStorageAccountNetworkRules) {
+	mapStandaloneStorageAccountNetworkRules = {}
+	for allStorageAccounts as _, accounts {
+		if keys(accounts.change.after) not contains "network_rules" {
+			for allStorageAccountNetworkRules as nr {
+				networkRuleStorageAccountName = allStorageAccountNetworkRules[nr]["change"]["after"]["storage_account_name"]
+				if networkRuleStorageAccountName is accounts.name {
+					mapStandaloneStorageAccountNetworkRules[networkRuleStorageAccountName] = nr
+				}
+			}
+		}
+	}
+	return length(mapStandaloneStorageAccountNetworkRules) == 1
+}
+
+# Check if standalone Storage Account Network Rules block(s) was defined.
+#
+# Network Rules can be defined either directly on the
+# azurerm_storage_account resource,
+# or using the
+# azurerm_storage_account_network_rules resource
+# - but the two cannot be used together.
+# Spurious changes will occur if both are used against the same Storage Account.
+#
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account_network_rules
+
+standalone_network_rules_have_bypass = rule {
+	all allStorageAccountNetworkRules as _, network_rules {
+		keys(network_rules.change.after) contains "bypass"
+	}
+}
+
+print("------------------------------------------------------------------------")
+print(allStorageAccountNetworkRules)
+print(keys(allStorageAccountNetworkRules))
+print(length(allStorageAccountNetworkRules))
+print(values(allStorageAccountNetworkRules))
+print(types.type_of(allStorageAccountNetworkRules))
+for allStorageAccountNetworkRules as _, network_rules {
+	print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+	print(types.type_of(network_rules))
+	print(types.type_of(network_rules["change"]["after"]["bypass"]))
+	print(network_rules["change"]["after"]["bypass"])
+	print(network_rules["change"]["after"]["bypass"] contains "AzureServices")
+	print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+}
+print("------------------------------------------------------------------------")
+
+standalone_network_rules_bypass_has_azure_services = rule when standalone_network_rules_have_bypass is true {
+	all allStorageAccountNetworkRules as _, network_rules {
+		network_rules["change"]["after"]["bypass"] contains "AzureServices"
+	}
+}
+
 main = rule {
-	deny_undefined_network_rules and
-	deny_undefined_network_rules_bypass and
-	network_rules_default_action_is_deny
+	(storage_account_has_built_in_network_rule(
+		allStorageAccounts, allStorageAccountNetworkRules) ==
+		true and
+		storage_account_has_built_in_network_rules and
+		storage_account_built_in_network_rules_have_bypass and
+		storage_account_built_in_network_rules_bypass_is_azure_services) or
+	(storage_account_has_standalone_storage_account_network_rule(
+		allStorageAccounts, allStorageAccountNetworkRules) ==
+		true and
+		standalone_network_rules_have_bypass and
+		standalone_network_rules_bypass_has_azure_services)
 }

--- a/cis/azure/storage/azure-cis-3.8-storage-trusted-microsoft-services-is-enabled/azure-cis-3.8-storage-trusted-microsoft-services-is-enabled.sentinel
+++ b/cis/azure/storage/azure-cis-3.8-storage-trusted-microsoft-services-is-enabled/azure-cis-3.8-storage-trusted-microsoft-services-is-enabled.sentinel
@@ -1,5 +1,4 @@
 import "tfplan/v2" as tfplan
-import "types"
 
 allStorageAccounts = filter tfplan.resource_changes as _, resource_changes {
 	resource_changes.mode is "managed" and
@@ -87,22 +86,6 @@ standalone_network_rules_have_bypass = rule {
 		keys(network_rules.change.after) contains "bypass"
 	}
 }
-
-print("------------------------------------------------------------------------")
-print(allStorageAccountNetworkRules)
-print(keys(allStorageAccountNetworkRules))
-print(length(allStorageAccountNetworkRules))
-print(values(allStorageAccountNetworkRules))
-print(types.type_of(allStorageAccountNetworkRules))
-for allStorageAccountNetworkRules as _, network_rules {
-	print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-	print(types.type_of(network_rules))
-	print(types.type_of(network_rules["change"]["after"]["bypass"]))
-	print(network_rules["change"]["after"]["bypass"])
-	print(network_rules["change"]["after"]["bypass"] contains "AzureServices")
-	print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-}
-print("------------------------------------------------------------------------")
 
 standalone_network_rules_bypass_has_azure_services = rule when standalone_network_rules_have_bypass is true {
 	all allStorageAccountNetworkRules as _, network_rules {

--- a/cis/azure/storage/azure-cis-3.8-storage-trusted-microsoft-services-is-enabled/testdata/mock-tfplan-failure.sentinel
+++ b/cis/azure/storage/azure-cis-3.8-storage-trusted-microsoft-services-is-enabled/testdata/mock-tfplan-failure.sentinel
@@ -62,7 +62,6 @@ resource_changes = {
 					},
 				],
 				"resource_group_name": "sentinel-foundational-azure",
-				"tags":                {},
 			},
 			"after_unknown": {},
 			"before":        {},
@@ -74,5 +73,110 @@ resource_changes = {
 		"name":           "this",
 		"provider_name":  "azurerm",
 		"type":           "azurerm_storage_account",
+	},
+	"azurerm_storage_account.account": {
+		"address": "azurerm_storage_account.account",
+		"change": {
+			"actions": [
+				"delete",
+				"create",
+			],
+			"after": {
+				"account_kind":             "StorageV2",
+				"account_replication_type": "LRS",
+				"account_tier":             "Standard",
+				"allow_blob_public_access": false,
+				"blob_properties": [
+					{
+						"cors_rule": [],
+						"delete_retention_policy": [
+							{
+								"days": 365,
+							},
+						],
+					},
+				],
+				"custom_domain":             [],
+				"enable_https_traffic_only": true,
+				"is_hns_enabled":            false,
+				"location":                  "westeurope",
+				"min_tls_version":           "TLS1_0",
+				"name":                      "account",
+				"queue_properties": [
+					{
+						"cors_rule": [],
+						"hour_metrics": [
+							{
+								"enabled":               true,
+								"include_apis":          true,
+								"retention_policy_days": 10,
+								"version":               "1.0",
+							},
+						],
+						"logging": [
+							{
+								"delete":                true,
+								"read":                  true,
+								"retention_policy_days": 10,
+								"version":               "1.0",
+								"write":                 true,
+							},
+						],
+						"minute_metrics": [
+							{
+								"enabled":               true,
+								"include_apis":          true,
+								"retention_policy_days": 10,
+								"version":               "1.0",
+							},
+						],
+					},
+				],
+				"resource_group_name": "sentinel-foundational-azure",
+				"static_website":      [],
+				"tags":                null,
+				"timeouts":            null,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "account",
+		"provider_name":  "azurerm",
+		"type":           "azurerm_storage_account",
+	},
+	"azurerm_storage_account_network_rules.rules": {
+		"address": "azurerm_storage_account_network_rules.rules",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"bypass": [
+					"None",
+				],
+				"default_action":       "Allow",
+				"resource_group_name":  "sentinel-foundational-azure",
+				"storage_account_name": "account",
+				"timeouts":             null,
+			},
+			"after_unknown": {
+				"bypass": [
+					false,
+				],
+				"id":                         true,
+				"ip_rules":                   true,
+				"virtual_network_subnet_ids": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "rules",
+		"provider_name":  "azurerm",
+		"type":           "azurerm_storage_account_network_rules",
 	},
 }

--- a/cis/azure/storage/azure-cis-3.8-storage-trusted-microsoft-services-is-enabled/testdata/mock-tfplan-success.sentinel
+++ b/cis/azure/storage/azure-cis-3.8-storage-trusted-microsoft-services-is-enabled/testdata/mock-tfplan-success.sentinel
@@ -62,7 +62,6 @@ resource_changes = {
 					},
 				],
 				"resource_group_name": "sentinel-foundational-azure",
-				"tags":                {},
 			},
 			"after_unknown": {},
 			"before":        {},
@@ -74,5 +73,110 @@ resource_changes = {
 		"name":           "this",
 		"provider_name":  "azurerm",
 		"type":           "azurerm_storage_account",
+	},
+	"azurerm_storage_account.account": {
+		"address": "azurerm_storage_account.account",
+		"change": {
+			"actions": [
+				"delete",
+				"create",
+			],
+			"after": {
+				"account_kind":             "StorageV2",
+				"account_replication_type": "LRS",
+				"account_tier":             "Standard",
+				"allow_blob_public_access": false,
+				"blob_properties": [
+					{
+						"cors_rule": [],
+						"delete_retention_policy": [
+							{
+								"days": 365,
+							},
+						],
+					},
+				],
+				"custom_domain":             [],
+				"enable_https_traffic_only": true,
+				"is_hns_enabled":            false,
+				"location":                  "westeurope",
+				"min_tls_version":           "TLS1_0",
+				"name":                      "account",
+				"queue_properties": [
+					{
+						"cors_rule": [],
+						"hour_metrics": [
+							{
+								"enabled":               true,
+								"include_apis":          true,
+								"retention_policy_days": 10,
+								"version":               "1.0",
+							},
+						],
+						"logging": [
+							{
+								"delete":                true,
+								"read":                  true,
+								"retention_policy_days": 10,
+								"version":               "1.0",
+								"write":                 true,
+							},
+						],
+						"minute_metrics": [
+							{
+								"enabled":               true,
+								"include_apis":          true,
+								"retention_policy_days": 10,
+								"version":               "1.0",
+							},
+						],
+					},
+				],
+				"resource_group_name": "sentinel-foundational-azure",
+				"static_website":      [],
+				"tags":                null,
+				"timeouts":            null,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "account",
+		"provider_name":  "azurerm",
+		"type":           "azurerm_storage_account",
+	},
+	"azurerm_storage_account_network_rules.rules": {
+		"address": "azurerm_storage_account_network_rules.rules",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"bypass": [
+					"AzureServices",
+				],
+				"default_action":       "Deny",
+				"resource_group_name":  "sentinel-foundational-azure",
+				"storage_account_name": "account",
+				"timeouts":             null,
+			},
+			"after_unknown": {
+				"bypass": [
+					false,
+				],
+				"id":                         true,
+				"ip_rules":                   true,
+				"virtual_network_subnet_ids": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "rules",
+		"provider_name":  "azurerm",
+		"type":           "azurerm_storage_account_network_rules",
 	},
 }


### PR DESCRIPTION
Check if built-in or standalone Storage Account Network Rules block(s) was defined.

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account_network_rules