### PR TITLE
Fix GFM links in table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This repository contains a library of policies that can be used within Terraform
 ## Table of Contents
 - [Prerequisites](#Prerequisites)
 - [Documentation](#documentation)
-- [Setup & Integration](#setup-&-integration)
-- [Version Control System (VCS)](#version-control-system-(vcs))
+- [Setup & Integration](#setup--integration)
+- [Version Control System (VCS)](#version-control-system-vcs)
 - [Policy Set Configuration](#policy-set-configuration)
 - [Policy Set Management](#policy-set-management)
 - [Policy Guides](#policy-guides)


### PR DESCRIPTION
GitHub-Flavored Markdown strips some special characters from headings when creating links.

They can be verified [by viewing the file directly](https://github.com/hashicorp/terraform-foundational-policies-library/blob/8924f099b75d1109de4aebf04a74a97345fa458b/README.md).