### PR TITLE
Resolving issue #41

### DIFF
--- a/cis/azure/storage/azure-cis-3.8-storage-trusted-microsoft-services-is-enabled/azure-cis-3.8-storage-trusted-microsoft-services-is-enabled.sentinel
+++ b/cis/azure/storage/azure-cis-3.8-storage-trusted-microsoft-services-is-enabled/azure-cis-3.8-storage-trusted-microsoft-services-is-enabled.sentinel
@@ -26,7 +26,7 @@ deny_undefined_network_rules_bypass = rule when deny_undefined_network_rules is 
 network_rules_default_action_is_deny = rule when deny_undefined_network_rules_bypass is true {
 	all allStorageAccounts as _, accounts {
 		all accounts.change.after.network_rules as network_rules {
-			all network_rules.bypass as bypass {
+			any network_rules.bypass as bypass {
 				bypass is "AzureServices"
 			}
 		}


### PR DESCRIPTION
Updated the quantifier expression in the `network_rules_default_action_is_deny` rule to use `any` instead of `all` when detecting Azure Services that are bypassed.