### PR TITLE
Fix aws-cis-4.{1,2} to handle delete actions

### DIFF
--- a/cis/aws/networking/aws-cis-4.1-networking-deny-public-ssh-acl-rules/aws-cis-4.1-networking-deny-public-ssh-acl-rules.sentinel
+++ b/cis/aws/networking/aws-cis-4.1-networking-deny-public-ssh-acl-rules/aws-cis-4.1-networking-deny-public-ssh-acl-rules.sentinel
@@ -1,19 +1,19 @@
 import "tfplan/v2" as tfplan
 
 aws_security_groups = filter tfplan.resource_changes as _, resource_changes {
-	length(resource_changes.change.after.ingress else []) != 0 and
-		resource_changes.mode is "managed" and
+	resource_changes.mode is "managed" and
 		resource_changes.type is "aws_security_group" and
 		(resource_changes.change.actions contains "create" or
-			resource_changes.change.actions is ["update"])
+			resource_changes.change.actions is ["update"]) and
+		length(resource_changes.change.after.ingress else []) != 0
 }
 
 aws_security_group_rules = filter tfplan.resource_changes as _, resource_changes {
 	resource_changes.mode is "managed" and
 		resource_changes.type is "aws_security_group_rule" and
-		resource_changes.change.after.type is "ingress" and
 		(resource_changes.change.actions contains "create" or
-			resource_changes.change.actions is ["update"])
+			resource_changes.change.actions is ["update"]) and
+		resource_changes.change.after.type is "ingress"
 }
 
 ssh_security_groups = filter aws_security_groups as _, asg {

--- a/cis/aws/networking/aws-cis-4.1-networking-deny-public-ssh-acl-rules/aws-cis-4.1-networking-deny-public-ssh-acl-rules.sentinel
+++ b/cis/aws/networking/aws-cis-4.1-networking-deny-public-ssh-acl-rules/aws-cis-4.1-networking-deny-public-ssh-acl-rules.sentinel
@@ -5,7 +5,7 @@ aws_security_groups = filter tfplan.resource_changes as _, resource_changes {
 		resource_changes.type is "aws_security_group" and
 		(resource_changes.change.actions contains "create" or
 			resource_changes.change.actions is ["update"]) and
-		length(resource_changes.change.after.ingress else []) != 0
+		(resource_changes.change.after.ingress else []) is not empty
 }
 
 aws_security_group_rules = filter tfplan.resource_changes as _, resource_changes {

--- a/cis/aws/networking/aws-cis-4.1-networking-deny-public-ssh-acl-rules/testdata/mock-tfplan-success.sentinel
+++ b/cis/aws/networking/aws-cis-4.1-networking-deny-public-ssh-acl-rules/testdata/mock-tfplan-success.sentinel
@@ -310,4 +310,38 @@ resource_changes = {
 		"provider_name":  "aws",
 		"type":           "aws_security_group_rule",
 	},
+	"aws_security_group_rule.delete": {
+		"address": "aws_security_group_rule.delete",
+		"change": {
+			"actions": [
+				"delete",
+			],
+			"after":         null,
+			"after_unknown": {},
+			"before": {
+				"arn": "arn:aws:ec2:us-east-1:123445667:security-group/sg-11223344551122334",
+				"cidr_blocks": [
+					"10.0.0.0/16",
+				],
+				"description":       "delete",
+				"from_port":         0,
+				"id":                "sg-11223344551122334",
+				"ipv6_cidr_blocks":  null,
+				"prefix_list_ids":   null,
+				"protocol":          "tcp",
+				"security_group_id": "sg-11223344551122334",
+				"self":              false,
+				"source_security_group_id": null,
+				"to_port":                  1024,
+				"type":                     "ingress",
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "delete",
+		"provider_name":  "aws",
+		"type":           "aws_security_group_rule",
+	},
 }

--- a/cis/aws/networking/aws-cis-4.2-networking-deny-public-rdp-acl-rules/aws-cis-4.2-networking-deny-public-rdp-acl-rules.sentinel
+++ b/cis/aws/networking/aws-cis-4.2-networking-deny-public-rdp-acl-rules/aws-cis-4.2-networking-deny-public-rdp-acl-rules.sentinel
@@ -1,19 +1,19 @@
 import "tfplan/v2" as tfplan
 
 aws_security_groups = filter tfplan.resource_changes as _, resource_changes {
-	length(resource_changes.change.after.ingress else []) != 0 and
-		resource_changes.mode is "managed" and
+	resource_changes.mode is "managed" and
 		resource_changes.type is "aws_security_group" and
 		(resource_changes.change.actions contains "create" or
-			resource_changes.change.actions is ["update"])
+			resource_changes.change.actions is ["update"]) and
+		length(resource_changes.change.after.ingress else []) != 0
 }
 
 aws_security_group_rules = filter tfplan.resource_changes as _, resource_changes {
 	resource_changes.mode is "managed" and
 		resource_changes.type is "aws_security_group_rule" and
-		resource_changes.change.after.type is "ingress" and
 		(resource_changes.change.actions contains "create" or
-			resource_changes.change.actions is ["update"])
+			resource_changes.change.actions is ["update"]) and
+		resource_changes.change.after.type is "ingress"
 }
 
 rdp_security_groups = filter aws_security_groups as _, asg {

--- a/cis/aws/networking/aws-cis-4.2-networking-deny-public-rdp-acl-rules/aws-cis-4.2-networking-deny-public-rdp-acl-rules.sentinel
+++ b/cis/aws/networking/aws-cis-4.2-networking-deny-public-rdp-acl-rules/aws-cis-4.2-networking-deny-public-rdp-acl-rules.sentinel
@@ -5,7 +5,7 @@ aws_security_groups = filter tfplan.resource_changes as _, resource_changes {
 		resource_changes.type is "aws_security_group" and
 		(resource_changes.change.actions contains "create" or
 			resource_changes.change.actions is ["update"]) and
-		length(resource_changes.change.after.ingress else []) != 0
+		(resource_changes.change.after.ingress else []) is not empty
 }
 
 aws_security_group_rules = filter tfplan.resource_changes as _, resource_changes {

--- a/cis/aws/networking/aws-cis-4.2-networking-deny-public-rdp-acl-rules/testdata/mock-tfplan-success.sentinel
+++ b/cis/aws/networking/aws-cis-4.2-networking-deny-public-rdp-acl-rules/testdata/mock-tfplan-success.sentinel
@@ -310,4 +310,38 @@ resource_changes = {
 		"provider_name":  "aws",
 		"type":           "aws_security_group_rule",
 	},
+	"aws_security_group_rule.delete": {
+		"address": "aws_security_group_rule.delete",
+		"change": {
+			"actions": [
+				"delete",
+			],
+			"after":         null,
+			"after_unknown": {},
+			"before": {
+				"arn": "arn:aws:ec2:us-east-1:123445667:security-group/sg-11223344551122334",
+				"cidr_blocks": [
+					"10.0.0.0/16",
+				],
+				"description":       "delete",
+				"from_port":         0,
+				"id":                "sg-11223344551122334",
+				"ipv6_cidr_blocks":  null,
+				"prefix_list_ids":   null,
+				"protocol":          "tcp",
+				"security_group_id": "sg-11223344551122334",
+				"self":              false,
+				"source_security_group_id": null,
+				"to_port":                  1024,
+				"type":                     "ingress",
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "delete",
+		"provider_name":  "aws",
+		"type":           "aws_security_group_rule",
+	},
 }


### PR DESCRIPTION
When planned to delete `after` is null so any condition needs to be
after `change.actions` is asserted