### PR TITLE
Adding deny public ssh policy

### DIFF
--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -1,0 +1,4 @@
+policy "aws-cis-4.1-networking-deny-public-ssh-acl-rules" {
+  source = "https://raw.githubusercontent.com/hashicorp/terraform-foundational-policies-library/master/cis/aws/networking/aws-cis-4.1-networking-deny-public-ssh-acl-rules/aws-cis-4.1-networking-deny-public-ssh-acl-rules.sentinel"
+  enforcement_level = "advisory"
+}


### PR DESCRIPTION
Adding an AWS policy to remove unfettered connectivity to remote console services, such as SSH, reduces a server's exposure to risk.